### PR TITLE
fix: #17 Retrieve Beacon Facets when logged-in

### DIFF
--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/services/BeaconFilteringTermsService.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/services/BeaconFilteringTermsService.java
@@ -113,8 +113,8 @@ public class BeaconFilteringTermsService {
         return termsGroupedByType.entrySet().stream()
                 .filter(entry -> facetIdsMappedByName.containsKey(entry.getKey()))
                 .map(entry -> Facet.builder()
-                        .key(entry.getKey())
-                        .label(facetIdsMappedByName.get(entry.getKey()))
+                        .key(facetIdsMappedByName.get(entry.getKey()))
+                        .label(entry.getKey())
                         .values(entry.getValue())
                         .build())
                 .toList();

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -31,6 +31,7 @@ quarkus.rest-client.ckan_yaml.url=http://localhost:4000
 quarkus.rest-client.keycloak_yaml.url=http://localhost:4000
 quarkus.rest-client.keycloak_yaml.beacon_idp_alias=LSAAI
 quarkus.rest-client.beacon_yaml.url=http://localhost:4000
+quarkus.rest-client.beacon_yaml.read-timeout=60000
 %dev.quarkus.oidc.auth-server-url=https://keycloak-test.healthdata.nl/realms/ckan
 %dev.quarkus.oidc.client-id=ckan
 %dev.quarkus.rest-client.ckan_yaml.url=https://ckan-test.healthdata.nl/

--- a/src/test/java/io/github/genomicdatainfrastructure/discovery/services/BeaconDatasetsSearchServiceTest.java
+++ b/src/test/java/io/github/genomicdatainfrastructure/discovery/services/BeaconDatasetsSearchServiceTest.java
@@ -1,0 +1,425 @@
+// SPDX-FileCopyrightText: 2024 PNED G.I.E.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package io.github.genomicdatainfrastructure.discovery.services;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import io.github.genomicdatainfrastructure.discovery.model.DatasetSearchQuery;
+import io.github.genomicdatainfrastructure.discovery.model.DatasetSearchQueryFacet;
+import io.github.genomicdatainfrastructure.discovery.model.DatasetsSearchResponse;
+import io.github.genomicdatainfrastructure.discovery.model.Facet;
+import io.github.genomicdatainfrastructure.discovery.model.FacetGroup;
+import io.github.genomicdatainfrastructure.discovery.model.SearchedDataset;
+import io.github.genomicdatainfrastructure.discovery.remote.beacon.api.BeaconQueryApi;
+import io.github.genomicdatainfrastructure.discovery.remote.beacon.model.BeaconIndividualsResponse;
+import io.github.genomicdatainfrastructure.discovery.remote.beacon.model.BeaconIndividualsResponseContent;
+import io.github.genomicdatainfrastructure.discovery.remote.beacon.model.BeaconResultSet;
+import io.github.genomicdatainfrastructure.discovery.remote.keycloak.api.KeycloakQueryApi;
+import io.github.genomicdatainfrastructure.discovery.remote.keycloak.model.KeycloakTokenResponse;
+import jakarta.ws.rs.WebApplicationException;
+
+class BeaconDatasetsSearchServiceTest {
+
+    private BeaconDatasetsSearchService underTest;
+    private BeaconQueryApi beaconQueryApi;
+    private KeycloakQueryApi keycloakQueryApi;
+    private CkanDatasetsSearchService ckanDatasetsSearchService;
+    private BeaconFilteringTermsService beaconFilteringTermsService;
+
+    @BeforeEach
+    void setUp() {
+        beaconQueryApi = mock(BeaconQueryApi.class);
+        keycloakQueryApi = mock(KeycloakQueryApi.class);
+        ckanDatasetsSearchService = mock(CkanDatasetsSearchService.class);
+        beaconFilteringTermsService = mock(BeaconFilteringTermsService.class);
+
+        underTest = new BeaconDatasetsSearchService(
+                beaconQueryApi,
+                "beaconIdpAlias",
+                keycloakQueryApi,
+                ckanDatasetsSearchService,
+                beaconFilteringTermsService
+        );
+    }
+
+    @Test
+    void doesnt_call_beacon_if_access_token_is_null() {
+        when(ckanDatasetsSearchService.search(any(), any()))
+                .thenReturn(DatasetsSearchResponse.builder()
+                        .count(1)
+                        .facetGroupCount(Map.of("group", 1))
+                        .results(List.of(
+                                SearchedDataset.builder()
+                                        .id("id")
+                                        .title("title")
+                                        .build()
+                        ))
+                        .build());
+
+        var query = DatasetSearchQuery.builder()
+                .build();
+        var actual = underTest.search(query, null);
+
+        verify(keycloakQueryApi, never()).retriveIdpTokens(any(), any());
+        verify(ckanDatasetsSearchService).search(any(), any());
+        verify(beaconFilteringTermsService, never()).listFilteringTerms(any());
+        verify(beaconQueryApi, never()).listIndividuals(any(), any());
+
+        assertThat(actual)
+                .usingRecursiveComparison()
+                .isEqualTo(DatasetsSearchResponse.builder()
+                        .count(1)
+                        .facetGroupCount(Map.of("group", 1))
+                        .results(List.of(
+                                SearchedDataset.builder()
+                                        .id("id")
+                                        .title("title")
+                                        .build()
+                        ))
+                        .build());
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {400, 401, 403})
+    void doesnt_call_beacon_if_keycloak_throws_expected_4xx_errors(Integer statusCode) {
+        when(ckanDatasetsSearchService.search(any(), any()))
+                .thenReturn(DatasetsSearchResponse.builder()
+                        .count(1)
+                        .facetGroupCount(Map.of("group", 1))
+                        .results(List.of(
+                                SearchedDataset.builder()
+                                        .id("id")
+                                        .title("title")
+                                        .build()
+                        ))
+                        .build());
+
+        when(keycloakQueryApi.retriveIdpTokens("beaconIdpAlias", "Bearer dummy"))
+                .thenThrow(new WebApplicationException(statusCode));
+
+        var query = DatasetSearchQuery.builder()
+                .build();
+        var actual = underTest.search(query, "dummy");
+
+        verify(keycloakQueryApi).retriveIdpTokens(any(), any());
+        verify(ckanDatasetsSearchService).search(any(), any());
+        verify(beaconFilteringTermsService, never()).listFilteringTerms(any());
+        verify(beaconQueryApi, never()).listIndividuals(any(), any());
+
+        assertThat(actual)
+                .usingRecursiveComparison()
+                .isEqualTo(DatasetsSearchResponse.builder()
+                        .count(1)
+                        .facetGroupCount(Map.of("group", 1))
+                        .results(List.of(
+                                SearchedDataset.builder()
+                                        .id("id")
+                                        .title("title")
+                                        .build()
+                        ))
+                        .build());
+    }
+
+    @Test
+    void doesnt_call_beacon_if_there_are_no_beacon_filters() {
+        when(ckanDatasetsSearchService.search(any(), any()))
+                .thenReturn(DatasetsSearchResponse.builder()
+                        .count(1)
+                        .facetGroupCount(Map.of("group", 1))
+                        .results(List.of(
+                                SearchedDataset.builder()
+                                        .id("id")
+                                        .title("title")
+                                        .build()
+                        ))
+                        .build());
+
+        when(beaconFilteringTermsService.listFilteringTerms(any()))
+                .thenReturn(FacetGroup.builder()
+                        .key("beacon")
+                        .label("label")
+                        .facets(List.of(
+                                Facet.builder()
+                                        .key("key")
+                                        .label("label")
+                                        .build()
+                        ))
+                        .build());
+
+        when(keycloakQueryApi.retriveIdpTokens("beaconIdpAlias", "Bearer dummy"))
+                .thenReturn(KeycloakTokenResponse.builder()
+                        .accessToken("beaconAccessToken")
+                        .build());
+
+        var query = DatasetSearchQuery.builder()
+                .build();
+        var actual = underTest.search(query, "dummy");
+
+        verify(keycloakQueryApi).retriveIdpTokens(any(), any());
+        verify(beaconQueryApi, never()).listIndividuals(any(), any());
+        verify(ckanDatasetsSearchService).search(any(), any());
+        verify(beaconFilteringTermsService).listFilteringTerms(any());
+
+        assertThat(actual)
+                .usingRecursiveComparison()
+                .isEqualTo(DatasetsSearchResponse.builder()
+                        .count(1)
+                        .facetGroupCount(Map.of(
+                                "group", 1,
+                                "beacon", 0
+                        ))
+                        .results(List.of(
+                                SearchedDataset.builder()
+                                        .id("id")
+                                        .title("title")
+                                        .build()
+                        ))
+                        .facetGroups(List.of(
+                                FacetGroup.builder()
+                                        .key("beacon")
+                                        .label("label")
+                                        .facets(List.of(
+                                                Facet.builder()
+                                                        .key("key")
+                                                        .label("label")
+                                                        .build()
+                                        ))
+                                        .build()
+                        ))
+                        .build());
+    }
+
+    private static Stream<BeaconIndividualsResponse> emptyBeaconResultsets() {
+        return Stream.of(
+                BeaconIndividualsResponse.builder()
+                        .response(null)
+                        .build(),
+                BeaconIndividualsResponse.builder()
+                        .response(BeaconIndividualsResponseContent.builder()
+                                .resultSets(List.of())
+                                .build())
+                        .build(),
+                BeaconIndividualsResponse.builder()
+                        .response(BeaconIndividualsResponseContent.builder()
+                                .resultSets(List.of(
+                                        BeaconResultSet.builder()
+                                                .id(null)
+                                                .resultsCount(1)
+                                                .setType("dataset")
+                                                .build()
+                                ))
+                                .build())
+                        .build(),
+                BeaconIndividualsResponse.builder()
+                        .response(BeaconIndividualsResponseContent.builder()
+                                .resultSets(List.of(
+                                        BeaconResultSet.builder()
+                                                .id("id")
+                                                .resultsCount(null)
+                                                .setType("dataset")
+                                                .build()
+                                ))
+                                .build())
+                        .build(),
+                BeaconIndividualsResponse.builder()
+                        .response(BeaconIndividualsResponseContent.builder()
+                                .resultSets(List.of(
+                                        BeaconResultSet.builder()
+                                                .id("id")
+                                                .resultsCount(1)
+                                                .setType(null)
+                                                .build()
+                                ))
+                                .build())
+                        .build()
+        );
+    }
+
+    @ParameterizedTest
+    @NullSource
+    @MethodSource("emptyBeaconResultsets")
+    void doesnt_call_ckan_if_there_are_no_beacon_resultsets(
+            BeaconIndividualsResponse beaconResponse
+    ) {
+        when(beaconQueryApi.listIndividuals(any(), any()))
+                .thenReturn(beaconResponse);
+
+        when(beaconFilteringTermsService.listFilteringTerms(any()))
+                .thenReturn(FacetGroup.builder()
+                        .key("beacon")
+                        .label("label")
+                        .facets(List.of(
+                                Facet.builder()
+                                        .key("key")
+                                        .label("label")
+                                        .build()
+                        ))
+                        .build());
+
+        when(keycloakQueryApi.retriveIdpTokens("beaconIdpAlias", "Bearer dummy"))
+                .thenReturn(KeycloakTokenResponse.builder()
+                        .accessToken("beaconAccessToken")
+                        .build());
+
+        var query = DatasetSearchQuery.builder()
+                .facets(List.of(
+                        DatasetSearchQueryFacet.builder()
+                                .facetGroup("beacon")
+                                .facet("key")
+                                .value("value")
+                                .build(
+                                )))
+                .build();
+        var actual = underTest.search(query, "dummy");
+
+        verify(keycloakQueryApi).retriveIdpTokens(any(), any());
+        verify(beaconQueryApi).listIndividuals(any(), any());
+        verify(ckanDatasetsSearchService, never()).search(any(), any());
+        verify(beaconFilteringTermsService).listFilteringTerms(any());
+
+        assertThat(actual)
+                .usingRecursiveComparison()
+                .isEqualTo(DatasetsSearchResponse.builder()
+                        .count(0)
+                        .facetGroupCount(Map.of(
+                                "beacon", 0
+                        ))
+                        .results(List.of())
+                        .facetGroups(List.of(
+                                FacetGroup.builder()
+                                        .key("beacon")
+                                        .label("label")
+                                        .facets(List.of(
+                                                Facet.builder()
+                                                        .key("key")
+                                                        .label("label")
+                                                        .build()
+                                        ))
+                                        .build()
+                        ))
+                        .build());
+    }
+
+    @Test
+    void calls_ckan_and_beacon() {
+        when(beaconQueryApi.listIndividuals(any(), any()))
+                .thenReturn(BeaconIndividualsResponse.builder()
+                        .response(BeaconIndividualsResponseContent.builder()
+                                .resultSets(List.of(
+                                        BeaconResultSet.builder()
+                                                .id("id")
+                                                .resultsCount(1)
+                                                .setType("dataset")
+                                                .build()
+                                ))
+                                .build())
+                        .build());
+
+        when(ckanDatasetsSearchService.search(any(), any()))
+                .thenReturn(DatasetsSearchResponse.builder()
+                        .count(1)
+                        .facetGroupCount(Map.of("group", 1))
+                        .results(List.of(
+                                SearchedDataset.builder()
+                                        .id("id")
+                                        .title("title")
+                                        .build()
+                        ))
+                        .build());
+
+        when(beaconFilteringTermsService.listFilteringTerms(any()))
+                .thenReturn(FacetGroup.builder()
+                        .key("beacon")
+                        .label("label")
+                        .facets(List.of(
+                                Facet.builder()
+                                        .key("key")
+                                        .label("label")
+                                        .build()
+                        ))
+                        .build());
+
+        when(keycloakQueryApi.retriveIdpTokens("beaconIdpAlias", "Bearer dummy"))
+                .thenReturn(KeycloakTokenResponse.builder()
+                        .accessToken("beaconAccessToken")
+                        .build());
+        when(beaconFilteringTermsService.listFilteringTerms(any()))
+                .thenReturn(FacetGroup.builder()
+                        .key("beacon")
+                        .label("label")
+                        .facets(List.of(
+                                Facet.builder()
+                                        .key("key")
+                                        .label("label")
+                                        .build()
+                        ))
+                        .build());
+
+        when(keycloakQueryApi.retriveIdpTokens("beaconIdpAlias", "Bearer dummy"))
+                .thenReturn(KeycloakTokenResponse.builder()
+                        .accessToken("beaconAccessToken")
+                        .build());
+
+        var query = DatasetSearchQuery.builder()
+                .facets(List.of(
+                        DatasetSearchQueryFacet.builder()
+                                .facetGroup("beacon")
+                                .facet("key")
+                                .value("value")
+                                .build(
+                                )))
+                .build();
+        var actual = underTest.search(query, "dummy");
+
+        verify(keycloakQueryApi).retriveIdpTokens(any(), any());
+        verify(beaconQueryApi).listIndividuals(any(), any());
+        verify(ckanDatasetsSearchService).search(any(), any());
+        verify(beaconFilteringTermsService).listFilteringTerms(any());
+
+        assertThat(actual)
+                .usingRecursiveComparison()
+                .isEqualTo(DatasetsSearchResponse.builder()
+                        .count(1)
+                        .facetGroupCount(Map.of(
+                                "group", 1,
+                                "beacon", 1
+                        ))
+                        .results(List.of(
+                                SearchedDataset.builder()
+                                        .id("id")
+                                        .title("title")
+                                        .build()
+                        ))
+                        .facetGroups(List.of(
+                                FacetGroup.builder()
+                                        .key("beacon")
+                                        .label("label")
+                                        .facets(List.of(
+                                                Facet.builder()
+                                                        .key("key")
+                                                        .label("label")
+                                                        .build()
+                                        ))
+                                        .build()
+                        ))
+                        .build());
+    }
+}


### PR DESCRIPTION
Beacon facets must be retrieved if the user is logged in, no matter if the user is using or not beacon facets to filter the results.

The class `BeaconDatasetsSearchService` was altered to comply to this requirement:
- if the user is not logged-in automatically CKAN query is triggered without enhancement. Check line 75.
- If there are beacon queries we trigger a search on Beacon Network. Check lines 79 and 109.
- if there are no beacon filters or beacon's resultsets is not empty, we query on CKAN. Check lines 81 and 134.
- Beacon facets/filters are always inserted into CKAN output. Check lines 87 and 175.

With those rules, we are able to properly enrich CKAN output with beacon response, including facets and resultsets, if there is any.

Several different test cases were introduced to cover most of the scenarios.