### PR TITLE
fix: retrieve multiple datasets from Beacon

### DIFF
--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/services/CkanFacetsQueryBuilder.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/services/CkanFacetsQueryBuilder.java
@@ -22,10 +22,11 @@ public class CkanFacetsQueryBuilder {
     private final String CKAN_FACET_GROUP = "ckan";
     private final String QUOTED_VALUE = "\"%s\"";
     private final String FACET_PATTERN = "%s:(%s)";
+    private final String AND = " AND ";
 
     public String buildFacetQuery(DatasetSearchQuery query) {
         var facets = query.getFacets();
-        var operator = query.getOperator();
+        var operator = CkanQueryOperatorMapper.getOperator(query.getOperator());
 
         var nonNullFacets = ofNullable(facets)
                 .orElseGet(List::of)
@@ -35,7 +36,7 @@ public class CkanFacetsQueryBuilder {
 
         return nonNullFacets.entrySet().stream()
                 .map(entry -> getFacetQuery(entry.getKey(), entry.getValue(), operator))
-                .collect(joining(CkanQueryOperatorMapper.getOperator(operator)));
+                .collect(joining(AND));
     }
 
     private Boolean isCkanGroupAndFacetIsNotBlank(DatasetSearchQueryFacet facet) {
@@ -46,11 +47,12 @@ public class CkanFacetsQueryBuilder {
                 !facet.getValue().isBlank();
     }
 
-    private String getFacetQuery(String key, List<DatasetSearchQueryFacet> facets,
-            DatasetSearchQuery.OperatorEnum operator) {
+    private String getFacetQuery(
+            String key, List<DatasetSearchQueryFacet> facets, String operator
+    ) {
         var values = facets.stream()
                 .map(facet -> QUOTED_VALUE.formatted(facet.getValue()))
-                .collect(joining(CkanQueryOperatorMapper.getOperator(operator)));
+                .collect(joining(operator));
 
         return FACET_PATTERN.formatted(key, values);
     }

--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/services/CkanQueryOperatorMapper.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/services/CkanQueryOperatorMapper.java
@@ -14,6 +14,6 @@ public class CkanQueryOperatorMapper {
     private final String OR = " OR ";
 
     public String getOperator(DatasetSearchQuery.OperatorEnum operator) {
-        return operator.equals(DatasetSearchQuery.OperatorEnum.OR) ? OR : AND;
+        return DatasetSearchQuery.OperatorEnum.AND.equals(operator) ? AND : OR;
     }
 }

--- a/src/main/openapi/discovery.yaml
+++ b/src/main/openapi/discovery.yaml
@@ -118,7 +118,7 @@ components:
           enum:
             - AND
             - OR
-          default: AND
+          default: OR
     DatasetSearchQueryFacet:
       type: object
       properties:

--- a/src/test/java/io/github/genomicdatainfrastructure/discovery/services/CkanFacetsQueryBuilderTest.java
+++ b/src/test/java/io/github/genomicdatainfrastructure/discovery/services/CkanFacetsQueryBuilderTest.java
@@ -79,7 +79,7 @@ class CkanFacetsQueryBuilderTest {
         query.setFacets(facets);
         query.setOperator(DatasetSearchQuery.OperatorEnum.OR);
 
-        var expected = "field1:(\"value1\" OR \"value2\") OR field2:(\"value3\")";
+        var expected = "field1:(\"value1\" OR \"value2\") AND field2:(\"value3\")";
         var actual = CkanFacetsQueryBuilder.buildFacetQuery(query);
         assertEquals(expected, actual);
     }


### PR DESCRIPTION
The default `AND` operator was causing a side-effect in the query. Beacon Network can retrieve multiple datasets ids, and from those ids we were querying again on CKAN, but there will never be a single dataset with multiple identifiers. To fix, the default operator was changed to query OR.

Besides that, reusing the `OR` operator between facets may case other side effects, like too open results, where retrieve datasets that do not contain the same variant/desease queried in beacon (e.g. `DOID:9256`). To avoid it, `AND` will be always the operator between facets.

We will revise the search engine, to improve user experience and performance, in a future story.