### PR TITLE
Added creator field to discovery service

### DIFF
--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/utils/PackageShowMapper.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/utils/PackageShowMapper.java
@@ -42,7 +42,7 @@ public class PackageShowMapper {
                 .url(ckanPackage.getUrl())
                 .languages(values(ckanPackage.getLanguage()))
                 .contact(value(ckanPackage.getContactUri()))
-                .creator(creators(ckanPackage))
+                .creators(creator(ckanPackage))
                 .hasVersions(values(ckanPackage.getHasVersion()))
                 .accessRights(value(ckanPackage.getAccessRights()))
                 .conformsTo(values(ckanPackage.getConformsTo()))
@@ -90,7 +90,7 @@ public class PackageShowMapper {
                 .build();
     }
 
-    private List<ValueLabel> creators(CkanPackage ckanPackage) {
+    private List<ValueLabel> creator(CkanPackage ckanPackage) {
         return ofNullable(ckanPackage.getCreators())
                 .orElseGet(List::of)
                 .stream()

--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/utils/PackageShowMapper.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/utils/PackageShowMapper.java
@@ -142,7 +142,7 @@ public class PackageShowMapper {
 
     }
 
-    private ValueLabel creator(Creator creator) {
+    private ValueLabel creator(CkanCreator creator) {
         return ValueLabel.builder()
                 .label(creator.getCreatorName())
                 .value(creator.getCreatorIdentifier())

--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/utils/PackageShowMapper.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/utils/PackageShowMapper.java
@@ -42,6 +42,7 @@ public class PackageShowMapper {
                 .url(ckanPackage.getUrl())
                 .languages(values(ckanPackage.getLanguage()))
                 .contact(value(ckanPackage.getContactUri()))
+                .creator(creators(ckanPackage))
                 .hasVersions(values(ckanPackage.getHasVersion()))
                 .accessRights(value(ckanPackage.getAccessRights()))
                 .conformsTo(values(ckanPackage.getConformsTo()))
@@ -89,6 +90,14 @@ public class PackageShowMapper {
                 .build();
     }
 
+    private List<ValueLabel> creators(CkanPackage ckanPackage) {
+        return ofNullable(ckanPackage.getCreators())
+                .orElseGet(List::of)
+                .stream()
+                .map(PackageShowMapper::creator)
+                .toList();
+    }
+
     private DatasetRelationEntry relation(CkanDatasetRelationEntry value) {
         return DatasetRelationEntry.builder()
                 .relation(value.getRelation())
@@ -131,6 +140,13 @@ public class PackageShowMapper {
                         .build())
                 .orElse(null);
 
+    }
+
+    private ValueLabel creator(Creator creator) {
+        return ValueLabel.builder()
+                .label(creator.getCreatorName())
+                .value(creator.getCreatorIdentifier())
+                .build();
     }
 
     private LocalDateTime parse(String date) {

--- a/src/main/openapi/ckan.yaml
+++ b/src/main/openapi/ckan.yaml
@@ -167,7 +167,7 @@ components:
         creators:
           type: array
           items:
-            $ref: "#/components/schemas/Creator"
+            $ref: "#/components/schemas/CkanCreator"
         datasetRelationships:
           type: array
           items:
@@ -228,7 +228,7 @@ components:
       required:
         - name
         - email
-    Creator:
+    CkanCreator:
       type: object
       properties:
         creator_name:

--- a/src/main/openapi/ckan.yaml
+++ b/src/main/openapi/ckan.yaml
@@ -164,6 +164,10 @@ components:
           items:
             $ref: "#/components/schemas/CkanContactPoint"
           title: Contacts
+        creators:
+          type: array
+          items:
+            $ref: "#/components/schemas/Creator"
         datasetRelationships:
           type: array
           items:
@@ -224,6 +228,16 @@ components:
       required:
         - name
         - email
+    Creator:
+      type: object
+      properties:
+        creator_name:
+          type: string
+        creator_identifier:
+          type: string
+      required:
+        - creator_name
+        - creator_identifier
     CkanDatasetRelationEntry:
       properties:
         relation:

--- a/src/main/openapi/discovery.yaml
+++ b/src/main/openapi/discovery.yaml
@@ -250,7 +250,7 @@ components:
         contact:
           $ref: "#/components/schemas/ValueLabel"
           title: Contact
-        creator:
+        creators:
           type: array
           items:
             $ref: "#/components/schemas/ValueLabel"

--- a/src/main/openapi/discovery.yaml
+++ b/src/main/openapi/discovery.yaml
@@ -250,6 +250,10 @@ components:
         contact:
           $ref: "#/components/schemas/ValueLabel"
           title: Contact
+        creator:
+          type: array
+          items:
+            $ref: "#/components/schemas/ValueLabel"
         hasVersions:
           type: array
           items:

--- a/src/test/java/io/github/genomicdatainfrastructure/discovery/services/PackageShowMapperTest.java
+++ b/src/test/java/io/github/genomicdatainfrastructure/discovery/services/PackageShowMapperTest.java
@@ -47,7 +47,7 @@ class PackageShowMapperTest {
                 .themes(List.of())
                 .keywords(List.of())
                 .contacts(List.of())
-                .creator(List.of())
+                .creators(List.of())
                 .datasetRelationships(List.of())
                 .dataDictionary(List.of())
                 .build();
@@ -178,7 +178,7 @@ class PackageShowMapperTest {
                                 .label("version")
                                 .build()
                 ))
-                .creator(List.of(
+                .creators(List.of(
                         ValueLabel.builder()
                                 .label("creatorName")
                                 .value("creatorIdentifier")

--- a/src/test/java/io/github/genomicdatainfrastructure/discovery/services/PackageShowMapperTest.java
+++ b/src/test/java/io/github/genomicdatainfrastructure/discovery/services/PackageShowMapperTest.java
@@ -11,6 +11,7 @@ import io.github.genomicdatainfrastructure.discovery.model.RetrievedDataset;
 import io.github.genomicdatainfrastructure.discovery.model.RetrievedDistribution;
 import io.github.genomicdatainfrastructure.discovery.model.ValueLabel;
 import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.CkanContactPoint;
+import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.Creator;
 import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.CkanDatasetDictionaryEntry;
 import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.CkanDatasetRelationEntry;
 import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.CkanOrganization;
@@ -46,6 +47,7 @@ class PackageShowMapperTest {
                 .themes(List.of())
                 .keywords(List.of())
                 .contacts(List.of())
+                .creator(List.of())
                 .datasetRelationships(List.of())
                 .dataDictionary(List.of())
                 .build();
@@ -123,6 +125,12 @@ class PackageShowMapperTest {
                         CkanContactPoint.builder().name("Contact 2").email("contact2@example.com")
                                 .build()
                 ))
+                .creators(List.of(
+                        Creator.builder()
+                                .creatorName("creatorName")
+                                .creatorIdentifier("creatorIdentifier")
+                                .build()
+                ))
                 .datasetRelationships(List.of(
                         CkanDatasetRelationEntry.builder().target("Dataset 1").relation(
                                 "Relation 1").build(),
@@ -168,6 +176,12 @@ class PackageShowMapperTest {
                         ValueLabel.builder()
                                 .value("1")
                                 .label("version")
+                                .build()
+                ))
+                .creator(List.of(
+                        ValueLabel.builder()
+                                .label("creatorName")
+                                .value("creatorIdentifier")
                                 .build()
                 ))
                 .accessRights(ValueLabel.builder()

--- a/src/test/java/io/github/genomicdatainfrastructure/discovery/services/PackageShowMapperTest.java
+++ b/src/test/java/io/github/genomicdatainfrastructure/discovery/services/PackageShowMapperTest.java
@@ -11,7 +11,7 @@ import io.github.genomicdatainfrastructure.discovery.model.RetrievedDataset;
 import io.github.genomicdatainfrastructure.discovery.model.RetrievedDistribution;
 import io.github.genomicdatainfrastructure.discovery.model.ValueLabel;
 import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.CkanContactPoint;
-import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.Creator;
+import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.CkanCreator;
 import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.CkanDatasetDictionaryEntry;
 import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.CkanDatasetRelationEntry;
 import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.CkanOrganization;
@@ -126,7 +126,7 @@ class PackageShowMapperTest {
                                 .build()
                 ))
                 .creators(List.of(
-                        Creator.builder()
+                        CkanCreator.builder()
                                 .creatorName("creatorName")
                                 .creatorIdentifier("creatorIdentifier")
                                 .build()


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: 2024 PNED G.I.E. -->

<!-- SPDX-License-Identifier: Apache-2.0 -->

## 🚀 Pull Request Checklist

- **Title:**

This PR exposes the CKAN creators field in the discovery service.

- **Description:**

See title.

- **Context:**

The field creator is currently not exposed in the discovery service, but its an essential part of DCAT-AP. It follows the same structure as publisher.

- **Changes:**

- OpenAPI defintion updated
- PackageMapper updated
- Tests updated

- **Testing:**

- Changes have been tested using Postman and internal fork of userportal frontend

- **Screenshots (if applicable):**

N/A

- **Additional Information:**

Code mostly done by my colleague @kburger and gratefully borrowed from his branch.

- **Checklist:**
  - `[X]` I have checked that my code adheres to the project's style guidelines and that my code is well-commented.
  - `[X]` I have performed self-review of my own code and corrected any misspellings.
  - `[X]` I have made corresponding changes to the documentation (if applicable).
  - `[X]` My changes generate no new warnings or errors.
  - `[X]` I have added tests that prove my fix is effective or that my feature works.
  - `[X]` New and existing unit tests pass locally with my changes.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Expose the 'creator' field in the discovery service by updating the OpenAPI definition and PackageMapper. Add corresponding tests to ensure proper functionality.

New Features:
- Expose the 'creator' field in the discovery service, following the same structure as the 'publisher' field.

Enhancements:
- Update OpenAPI definition to include the 'creator' field.
- Update PackageMapper to map the 'creator' field from CKAN packages.

Tests:
- Add tests to verify the correct parsing and mapping of the 'creator' field in CKAN packages.

<!-- Generated by sourcery-ai[bot]: end summary -->