### PR TITLE
fix: fix contact point parsing

### DIFF
--- a/_http/ckan.http
+++ b/_http/ckan.http
@@ -8,7 +8,7 @@ GET https://catalogue.portal.dev.gdi.lu/api/3/action/enhanced_package_search?fq=
 GET https://catalogue.portal.dev.gdi.lu/api/3/action/enhanced_package_show?id=bc7664b4-284a-44c0-9ce8-bc3d6882e7fe
 
 ###
-GET https://catalogue.portal.dev.gdi.lu/api/3/action/enhanced_package_show?id=dummy
+GET https://catalogue.portal.dev.gdi.lu/api/3/action/enhanced_package_show?id=bc7664b4-284a-44c0-9ce8-bc3d6882e7fe
 
 ###
 GET https://catalogue.portal.dev.gdi.lu/api/3/action/enhanced_package_show?id=dummy

--- a/_http/discovery.http
+++ b/_http/discovery.http
@@ -36,7 +36,7 @@ Content-Type: application/json
 }
 
 ###
-GET http://localhost:8080/api/v1/datasets/577f4d4b-a861-4178-91d5-f46019174193
+GET http://localhost:8080/api/v1/datasets/bc7664b4-284a-44c0-9ce8-bc3d6882e7fe
 
 ###
 GET http://localhost:8080/api/v1/datasets/dummy
@@ -45,4 +45,4 @@ GET http://localhost:8080/api/v1/datasets/dummy
 GET http://localhost:8080/api/v1/datasets/577f4d4b-a861-4178-91d5-f46019174193.ttl
 
 ###
-GET http://localhost:8080/api/v1/organizations
+GET https://api.portal.dev.gdi.lu/discovery/api/v1/organizations

--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/utils/PackageShowMapper.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/utils/PackageShowMapper.java
@@ -51,7 +51,7 @@ public class PackageShowMapper {
                 .spatial(value(ckanPackage.getSpatialUri()))
                 .distributions(distributions(ckanPackage))
                 .keywords(keywords(ckanPackage))
-                .contacts(contactPoint(ckanPackage.getContacts()))
+                .contacts(contactPoint(ckanPackage.getContactPoint()))
                 .datasetRelationships(relations(ckanPackage.getDatasetRelationships()))
                 .dataDictionary(dictionary(ckanPackage.getDataDictionary()))
                 .build();
@@ -86,8 +86,8 @@ public class PackageShowMapper {
 
     private ContactPoint contactPointEntry(CkanContactPoint value) {
         return ContactPoint.builder()
-                .name(value.getName())
-                .email(value.getEmail())
+                .name(value.getContactName())
+                .email(value.getContactEmail())
                 .build();
     }
 

--- a/src/main/openapi/ckan.yaml
+++ b/src/main/openapi/ckan.yaml
@@ -235,11 +235,10 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/CkanTag"
-        contacts:
+        contact_point:
           type: array
           items:
             $ref: "#/components/schemas/CkanContactPoint"
-          title: Contacts
         creators:
           type: array
           items:
@@ -295,15 +294,15 @@ components:
         - title
     CkanContactPoint:
       properties:
-        name:
+        contact_name:
           type: string
           title: name
-        email:
+        contact_email:
           type: string
           title: email
-      required:
-        - name
-        - email
+        contact_uri:
+          type: string
+          title: email
     CkanCreator:
       type: object
       properties:

--- a/src/main/openapi/discovery.yaml
+++ b/src/main/openapi/discovery.yaml
@@ -348,7 +348,7 @@ components:
           title: Keywords
         provenance:
           type: string
-          title: Contact URI
+          title: Provenance
         spatial:
           $ref: "#/components/schemas/ValueLabel"
           title: Spatial

--- a/src/test/java/io/github/genomicdatainfrastructure/discovery/services/PackageShowMapperTest.java
+++ b/src/test/java/io/github/genomicdatainfrastructure/discovery/services/PackageShowMapperTest.java
@@ -116,10 +116,14 @@ class PackageShowMapperTest {
                                 .lastModified("2024-03-19T13:37:05.472970")
                                 .build()
                 ))
-                .contacts(List.of(
-                        CkanContactPoint.builder().name("Contact 1").email("contact1@example.com")
+                .contactPoint(List.of(
+                        CkanContactPoint.builder()
+                                .contactName("Contact 1")
+                                .contactEmail("contact1@example.com")
                                 .build(),
-                        CkanContactPoint.builder().name("Contact 2").email("contact2@example.com")
+                        CkanContactPoint.builder()
+                                .contactName("Contact 2")
+                                .contactEmail("contact2@example.com")
                                 .build()
                 ))
                 .creators(List.of(

--- a/src/test/resources/mappings/package_show.json
+++ b/src/test/resources/mappings/package_show.json
@@ -72,6 +72,13 @@
                     "state": "active",
                     "temporal_end": "2025-12-31",
                     "temporal_start": "2020-01-01",
+                    "contact_point": [
+                        {
+                            "contact_email": "file:///srv/app/cto@biodata.pt",
+                            "contact_name": "Chief Technology Officer of BioData.pt",
+                            "contact_uri": ""
+                        }
+                    ],
                     "theme": [
                         {
                             "display_name": "Bio ontology",


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix contact point parsing by renaming 'contacts' to 'contact_point' and updating the 'CkanContactPoint' schema to use 'contact_name', 'contact_email', and 'contact_uri'. Update related tests to reflect these changes.

Bug Fixes:
- Correct the parsing of contact points by renaming 'contacts' to 'contact_point' in the OpenAPI specification and related code.

Enhancements:
- Update the 'CkanContactPoint' schema to use 'contact_name', 'contact_email', and 'contact_uri' instead of 'name' and 'email'.

Tests:
- Modify tests to reflect the changes in contact point parsing and schema updates.

<!-- Generated by sourcery-ai[bot]: end summary -->