### PR TITLE
fix: compatibility of CKAN creator field with new scheming

### DIFF
--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/utils/PackageShowMapper.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/utils/PackageShowMapper.java
@@ -93,7 +93,7 @@ public class PackageShowMapper {
     }
 
     private List<ValueLabel> creator(CkanPackage ckanPackage) {
-        return ofNullable(ckanPackage.getCreators())
+        return ofNullable(ckanPackage.getCreator())
                 .orElseGet(List::of)
                 .stream()
                 .map(PackageShowMapper::creator)

--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/utils/PackageShowMapper.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/utils/PackageShowMapper.java
@@ -42,6 +42,7 @@ public class PackageShowMapper {
                 .modifiedAt(parse(ckanPackage.getMetadataModified()))
                 .url(ckanPackage.getUrl())
                 .languages(values(ckanPackage.getLanguage()))
+                .contact(value(ckanPackage.getContactUri()))
                 .creators(creator(ckanPackage))
                 .hasVersions(values(ckanPackage.getHasVersion()))
                 .accessRights(value(ckanPackage.getAccessRights()))
@@ -50,10 +51,19 @@ public class PackageShowMapper {
                 .spatial(value(ckanPackage.getSpatialUri()))
                 .distributions(distributions(ckanPackage))
                 .keywords(keywords(ckanPackage))
-                .contacts(contactPointEntry(ckanPackage))
+                .contacts(contactPoint(ckanPackage.getContactPoint()))
                 .datasetRelationships(relations(ckanPackage.getDatasetRelationships()))
                 .dataDictionary(dictionary(ckanPackage.getDataDictionary()))
                 .build();
+    }
+
+    private List<ContactPoint> contactPoint(List<CkanContactPoint> values) {
+        return ofNullable(values)
+                .orElseGet(List::of)
+                .stream()
+                .filter(Objects::nonNull)
+                .map(PackageShowMapper::contactPointEntry)
+                .toList();
     }
 
     private List<DatasetRelationEntry> relations(List<CkanDatasetRelationEntry> values) {
@@ -74,12 +84,12 @@ public class PackageShowMapper {
                 .toList();
     }
 
-    private List<ContactPoint> contactPointEntry(CkanPackage ckanPackage) {
-        return List.of(ContactPoint.builder()
-                .name(ckanPackage.getContactName())
-                .email(ckanPackage.getContactEmail())
-                .uri(ckanPackage.getContactUri())
-                .build());
+    private ContactPoint contactPointEntry(CkanContactPoint value) {
+        return ContactPoint.builder()
+                .name(value.getContactName())
+                .email(value.getContactEmail())
+                .uri(value.getContactUri())
+                .build();
     }
 
     private List<ValueLabel> creator(CkanPackage ckanPackage) {

--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/utils/PackageShowMapper.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/utils/PackageShowMapper.java
@@ -42,7 +42,6 @@ public class PackageShowMapper {
                 .modifiedAt(parse(ckanPackage.getMetadataModified()))
                 .url(ckanPackage.getUrl())
                 .languages(values(ckanPackage.getLanguage()))
-                .contact(value(ckanPackage.getContactUri()))
                 .creators(creator(ckanPackage))
                 .hasVersions(values(ckanPackage.getHasVersion()))
                 .accessRights(value(ckanPackage.getAccessRights()))
@@ -51,19 +50,10 @@ public class PackageShowMapper {
                 .spatial(value(ckanPackage.getSpatialUri()))
                 .distributions(distributions(ckanPackage))
                 .keywords(keywords(ckanPackage))
-                .contacts(contactPoint(ckanPackage.getContactPoint()))
+                .contacts(contactPointEntry(ckanPackage))
                 .datasetRelationships(relations(ckanPackage.getDatasetRelationships()))
                 .dataDictionary(dictionary(ckanPackage.getDataDictionary()))
                 .build();
-    }
-
-    private List<ContactPoint> contactPoint(List<CkanContactPoint> values) {
-        return ofNullable(values)
-                .orElseGet(List::of)
-                .stream()
-                .filter(Objects::nonNull)
-                .map(PackageShowMapper::contactPointEntry)
-                .toList();
     }
 
     private List<DatasetRelationEntry> relations(List<CkanDatasetRelationEntry> values) {
@@ -84,12 +74,12 @@ public class PackageShowMapper {
                 .toList();
     }
 
-    private ContactPoint contactPointEntry(CkanContactPoint value) {
-        return ContactPoint.builder()
-                .name(value.getContactName())
-                .email(value.getContactEmail())
-                .uri(value.getContactUri())
-                .build();
+    private List<ContactPoint> contactPointEntry(CkanPackage ckanPackage) {
+        return List.of(ContactPoint.builder()
+                .name(ckanPackage.getContactName())
+                .email(ckanPackage.getContactEmail())
+                .uri(ckanPackage.getContactUri())
+                .build());
     }
 
     private List<ValueLabel> creator(CkanPackage ckanPackage) {

--- a/src/main/openapi/ckan.yaml
+++ b/src/main/openapi/ckan.yaml
@@ -235,6 +235,10 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/CkanTag"
+        contact_point:
+          type: array
+          items:
+            $ref: "#/components/schemas/CkanContactPoint"
         creator:
           type: array
           items:
@@ -263,15 +267,8 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/CkanValueLabel"
-        contact_name:
-          type: string
-          title: name
-        contact_email:
-          type: string
-          title: email
         contact_uri:
           type: string
-          title: uri
         has_version:
           type: array
           items:
@@ -295,6 +292,20 @@ components:
       required:
         - id
         - title
+    CkanContactPoint:
+      properties:
+        contact_name:
+          type: string
+          title: name
+        contact_email:
+          type: string
+          title: email
+        contact_uri:
+          type: string
+          title: uri
+      required:
+        - name
+        - email
     CkanCreator:
       type: object
       properties:

--- a/src/main/openapi/ckan.yaml
+++ b/src/main/openapi/ckan.yaml
@@ -235,10 +235,6 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/CkanTag"
-        contact_point:
-          type: array
-          items:
-            $ref: "#/components/schemas/CkanContactPoint"
         creator:
           type: array
           items:
@@ -267,8 +263,15 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/CkanValueLabel"
+        contact_name:
+          type: string
+          title: name
+        contact_email:
+          type: string
+          title: email
         contact_uri:
           type: string
+          title: uri
         has_version:
           type: array
           items:
@@ -292,20 +295,6 @@ components:
       required:
         - id
         - title
-    CkanContactPoint:
-      properties:
-        contact_name:
-          type: string
-          title: name
-        contact_email:
-          type: string
-          title: email
-        contact_uri:
-          type: string
-          title: uri
-      required:
-        - name
-        - email
     CkanCreator:
       type: object
       properties:

--- a/src/main/openapi/ckan.yaml
+++ b/src/main/openapi/ckan.yaml
@@ -239,7 +239,7 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/CkanContactPoint"
-        creators:
+        creator:
           type: array
           items:
             $ref: "#/components/schemas/CkanCreator"

--- a/src/test/java/io/github/genomicdatainfrastructure/discovery/services/PackageShowMapperTest.java
+++ b/src/test/java/io/github/genomicdatainfrastructure/discovery/services/PackageShowMapperTest.java
@@ -5,6 +5,7 @@
 package io.github.genomicdatainfrastructure.discovery.services;
 
 import io.github.genomicdatainfrastructure.discovery.model.*;
+import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.CkanContactPoint;
 import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.CkanCreator;
 import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.CkanDatasetDictionaryEntry;
 import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.CkanDatasetRelationEntry;
@@ -82,8 +83,6 @@ class PackageShowMapperTest {
                                 .name("en")
                                 .build()))
                 .contactUri("contactUri")
-                .contactEmail("contactEmail")
-                .contactName("contactName")
                 .hasVersion(List.of(
                         CkanValueLabel.builder()
                                 .displayName("version")
@@ -115,22 +114,37 @@ class PackageShowMapperTest {
                                 .uri("uri")
                                 .created("2024-03-19T13:37:05.472970")
                                 .lastModified("2024-03-19T13:37:05.472970")
-                                .build()))
+                                .build()
+                ))
+                .contactPoint(List.of(
+                        CkanContactPoint.builder()
+                                .contactName("Contact 1")
+                                .contactEmail("contact1@example.com")
+                                .build(),
+                        CkanContactPoint.builder()
+                                .contactName("Contact 2")
+                                .contactEmail("contact2@example.com")
+                                .contactUri("http://example.com")
+                                .build()
+                ))
                 .creator(List.of(
                         CkanCreator.builder()
                                 .creatorName("creatorName")
                                 .creatorIdentifier("creatorIdentifier")
-                                .build()))
+                                .build()
+                ))
                 .datasetRelationships(List.of(
                         CkanDatasetRelationEntry.builder().target("Dataset 1").relation(
                                 "Relation 1").build(),
                         CkanDatasetRelationEntry.builder().target("Dataset 2").relation(
-                                "Relation 2").build()))
+                                "Relation 2").build()
+                ))
                 .dataDictionary(List.of(
                         CkanDatasetDictionaryEntry.builder().name("Entry 1").type("Type 1")
                                 .description("Description 1").build(),
                         CkanDatasetDictionaryEntry.builder().name("Entry 2").type("Type 2")
-                                .description("Description 2").build()))
+                                .description("Description 2").build()
+                ))
                 .build();
 
         var actual = PackageShowMapper.from(ckanPackage);
@@ -143,7 +157,8 @@ class PackageShowMapperTest {
                         ValueLabel.builder()
                                 .value("theme-name")
                                 .label("theme")
-                                .build()))
+                                .build()
+                ))
                 .publisherName("publisherName")
                 .catalogue("organization")
                 .createdAt(parse("2024-03-19T13:37:05.472970", DATE_FORMATTER))
@@ -153,17 +168,24 @@ class PackageShowMapperTest {
                         ValueLabel.builder()
                                 .value("en")
                                 .label("language")
-                                .build()))
+                                .build()
+                ))
+                .contact(ValueLabel.builder()
+                        .value("contactUri")
+                        .label("contactUri")
+                        .build())
                 .hasVersions(List.of(
                         ValueLabel.builder()
                                 .value("1")
                                 .label("version")
-                                .build()))
+                                .build()
+                ))
                 .creators(List.of(
                         ValueLabel.builder()
                                 .label("creatorName")
                                 .value("creatorIdentifier")
-                                .build()))
+                                .build()
+                ))
                 .accessRights(ValueLabel.builder()
                         .value("public")
                         .label("accessRights")
@@ -172,7 +194,8 @@ class PackageShowMapperTest {
                         ValueLabel.builder()
                                 .value("conforms")
                                 .label("conformsTo")
-                                .build()))
+                                .build()
+                ))
                 .organization(DatasetOrganization
                         .builder()
                         .title("organization")
@@ -198,33 +221,33 @@ class PackageShowMapperTest {
                                         .label("format")
                                         .build())
                                 .uri("uri")
-                                .createdAt(parse("2024-03-19T13:37:05.472970",
-                                        DATE_FORMATTER))
-                                .modifiedAt(parse("2024-03-19T13:37:05.472970",
-                                        DATE_FORMATTER))
-                                .build()))
+                                .createdAt(parse("2024-03-19T13:37:05.472970", DATE_FORMATTER))
+                                .modifiedAt(parse("2024-03-19T13:37:05.472970", DATE_FORMATTER))
+                                .build()
+                ))
                 .contacts(List.of(
                         ContactPoint.builder()
-                                .name("contactName")
-                                .email("contactEmail")
-                                .uri("contactUri")
-                                .build()))
+                                .name("Contact 1")
+                                .email("contact1@example.com")
+                                .build(),
+                        ContactPoint.builder()
+                                .name("Contact 2")
+                                .email("contact2@example.com")
+                                .uri("http://example.com")
+                                .build()
+                ))
                 .datasetRelationships(List.of(
-                        DatasetRelationEntry.builder().relation("Relation 1")
-                                .target("Dataset 1")
+                        DatasetRelationEntry.builder().relation("Relation 1").target("Dataset 1")
                                 .build(),
-                        DatasetRelationEntry.builder().relation("Relation 2")
-                                .target("Dataset 2")
-                                .build()))
+                        DatasetRelationEntry.builder().relation("Relation 2").target("Dataset 2")
+                                .build()
+                ))
                 .dataDictionary(List.of(
-                        DatasetDictionaryEntry.builder().name("Entry 1").type("Type 1")
-                                .description(
-                                        "Description 1")
-                                .build(),
-                        DatasetDictionaryEntry.builder().name("Entry 2").type("Type 2")
-                                .description(
-                                        "Description 2")
-                                .build()))
+                        DatasetDictionaryEntry.builder().name("Entry 1").type("Type 1").description(
+                                "Description 1").build(),
+                        DatasetDictionaryEntry.builder().name("Entry 2").type("Type 2").description(
+                                "Description 2").build()
+                ))
                 .build();
 
         assertThat(actual)

--- a/src/test/java/io/github/genomicdatainfrastructure/discovery/services/PackageShowMapperTest.java
+++ b/src/test/java/io/github/genomicdatainfrastructure/discovery/services/PackageShowMapperTest.java
@@ -5,7 +5,6 @@
 package io.github.genomicdatainfrastructure.discovery.services;
 
 import io.github.genomicdatainfrastructure.discovery.model.*;
-import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.CkanContactPoint;
 import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.CkanCreator;
 import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.CkanDatasetDictionaryEntry;
 import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.CkanDatasetRelationEntry;
@@ -83,6 +82,8 @@ class PackageShowMapperTest {
                                 .name("en")
                                 .build()))
                 .contactUri("contactUri")
+                .contactEmail("contactEmail")
+                .contactName("contactName")
                 .hasVersion(List.of(
                         CkanValueLabel.builder()
                                 .displayName("version")
@@ -114,37 +115,22 @@ class PackageShowMapperTest {
                                 .uri("uri")
                                 .created("2024-03-19T13:37:05.472970")
                                 .lastModified("2024-03-19T13:37:05.472970")
-                                .build()
-                ))
-                .contactPoint(List.of(
-                        CkanContactPoint.builder()
-                                .contactName("Contact 1")
-                                .contactEmail("contact1@example.com")
-                                .build(),
-                        CkanContactPoint.builder()
-                                .contactName("Contact 2")
-                                .contactEmail("contact2@example.com")
-                                .contactUri("http://example.com")
-                                .build()
-                ))
+                                .build()))
                 .creator(List.of(
                         CkanCreator.builder()
                                 .creatorName("creatorName")
                                 .creatorIdentifier("creatorIdentifier")
-                                .build()
-                ))
+                                .build()))
                 .datasetRelationships(List.of(
                         CkanDatasetRelationEntry.builder().target("Dataset 1").relation(
                                 "Relation 1").build(),
                         CkanDatasetRelationEntry.builder().target("Dataset 2").relation(
-                                "Relation 2").build()
-                ))
+                                "Relation 2").build()))
                 .dataDictionary(List.of(
                         CkanDatasetDictionaryEntry.builder().name("Entry 1").type("Type 1")
                                 .description("Description 1").build(),
                         CkanDatasetDictionaryEntry.builder().name("Entry 2").type("Type 2")
-                                .description("Description 2").build()
-                ))
+                                .description("Description 2").build()))
                 .build();
 
         var actual = PackageShowMapper.from(ckanPackage);
@@ -157,8 +143,7 @@ class PackageShowMapperTest {
                         ValueLabel.builder()
                                 .value("theme-name")
                                 .label("theme")
-                                .build()
-                ))
+                                .build()))
                 .publisherName("publisherName")
                 .catalogue("organization")
                 .createdAt(parse("2024-03-19T13:37:05.472970", DATE_FORMATTER))
@@ -168,24 +153,17 @@ class PackageShowMapperTest {
                         ValueLabel.builder()
                                 .value("en")
                                 .label("language")
-                                .build()
-                ))
-                .contact(ValueLabel.builder()
-                        .value("contactUri")
-                        .label("contactUri")
-                        .build())
+                                .build()))
                 .hasVersions(List.of(
                         ValueLabel.builder()
                                 .value("1")
                                 .label("version")
-                                .build()
-                ))
+                                .build()))
                 .creators(List.of(
                         ValueLabel.builder()
                                 .label("creatorName")
                                 .value("creatorIdentifier")
-                                .build()
-                ))
+                                .build()))
                 .accessRights(ValueLabel.builder()
                         .value("public")
                         .label("accessRights")
@@ -194,8 +172,7 @@ class PackageShowMapperTest {
                         ValueLabel.builder()
                                 .value("conforms")
                                 .label("conformsTo")
-                                .build()
-                ))
+                                .build()))
                 .organization(DatasetOrganization
                         .builder()
                         .title("organization")
@@ -221,33 +198,33 @@ class PackageShowMapperTest {
                                         .label("format")
                                         .build())
                                 .uri("uri")
-                                .createdAt(parse("2024-03-19T13:37:05.472970", DATE_FORMATTER))
-                                .modifiedAt(parse("2024-03-19T13:37:05.472970", DATE_FORMATTER))
-                                .build()
-                ))
+                                .createdAt(parse("2024-03-19T13:37:05.472970",
+                                        DATE_FORMATTER))
+                                .modifiedAt(parse("2024-03-19T13:37:05.472970",
+                                        DATE_FORMATTER))
+                                .build()))
                 .contacts(List.of(
                         ContactPoint.builder()
-                                .name("Contact 1")
-                                .email("contact1@example.com")
-                                .build(),
-                        ContactPoint.builder()
-                                .name("Contact 2")
-                                .email("contact2@example.com")
-                                .uri("http://example.com")
-                                .build()
-                ))
+                                .name("contactName")
+                                .email("contactEmail")
+                                .uri("contactUri")
+                                .build()))
                 .datasetRelationships(List.of(
-                        DatasetRelationEntry.builder().relation("Relation 1").target("Dataset 1")
+                        DatasetRelationEntry.builder().relation("Relation 1")
+                                .target("Dataset 1")
                                 .build(),
-                        DatasetRelationEntry.builder().relation("Relation 2").target("Dataset 2")
-                                .build()
-                ))
+                        DatasetRelationEntry.builder().relation("Relation 2")
+                                .target("Dataset 2")
+                                .build()))
                 .dataDictionary(List.of(
-                        DatasetDictionaryEntry.builder().name("Entry 1").type("Type 1").description(
-                                "Description 1").build(),
-                        DatasetDictionaryEntry.builder().name("Entry 2").type("Type 2").description(
-                                "Description 2").build()
-                ))
+                        DatasetDictionaryEntry.builder().name("Entry 1").type("Type 1")
+                                .description(
+                                        "Description 1")
+                                .build(),
+                        DatasetDictionaryEntry.builder().name("Entry 2").type("Type 2")
+                                .description(
+                                        "Description 2")
+                                .build()))
                 .build();
 
         assertThat(actual)

--- a/src/test/java/io/github/genomicdatainfrastructure/discovery/services/PackageShowMapperTest.java
+++ b/src/test/java/io/github/genomicdatainfrastructure/discovery/services/PackageShowMapperTest.java
@@ -127,7 +127,7 @@ class PackageShowMapperTest {
                                 .contactUri("http://example.com")
                                 .build()
                 ))
-                .creators(List.of(
+                .creator(List.of(
                         CkanCreator.builder()
                                 .creatorName("creatorName")
                                 .creatorIdentifier("creatorIdentifier")


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: 2024 PNED G.I.E. -->

<!-- SPDX-License-Identifier: Apache-2.0 -->

## 🚀 Pull Request Checklist

- **Title:**

  - `[X]` A brief, descriptive title for the changes.

Make sure scheming is compatible with CKAN

- **Description:**

  - `[X]` Provide a clear and concise description of your pull request, including the purpose of the changes and the approach you've taken.

Note: this PR only works with the new scheming in the main branch of the gdi-userportal-extension.

This PR restores compatibility with CKAN. The creator field in CKAN (even though multi-valued), is still singular.

- **Context:**

  - `[X]` Why are these changes necessary? What problem do they solve? Link any related issues.

Currently, it's broken.

- **Changes:**

  - `[X]` List the major changes you've made, ideally organized by commit or feature.
Just one commit.

- **Testing:**

  - `[X]` Describe how the changes have been tested. Include any relevant details about the testing environment and the test cases.

Tested with local CKAN, gdi-userportal extension, rev 9f44efa61

- **Screenshots (if applicable):**

  - `[X]` If your changes are visual, include screenshots to help explain your changes.

N/A

- **Additional Information:**

  - `[X]` Add any other information that might be useful for reviewers, such as considerations, discussions, or dependencies.

N/A

- **Checklist:**
  - `[X]` I have checked that my code adheres to the project's style guidelines and that my code is well-commented.
  - `[X]` I have performed self-review of my own code and corrected any misspellings.
  - `[X]` I have made corresponding changes to the documentation (if applicable).
  - `[X]` My changes generate no new warnings or errors.
  - `[X]` I have added tests that prove my fix is effective or that my feature works.
  - `[X]` New and existing unit tests pass locally with my changes.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Restore compatibility with CKAN by updating the creator field to be singular, ensuring it works with the new scheming in the gdi-userportal-extension.

Bug Fixes:
- Fix compatibility issue with CKAN by updating the creator field to align with the new scheming requirements.

<!-- Generated by sourcery-ai[bot]: end summary -->