### PR TITLE
Replace "title" by "title_string" in sort string in CKAN API calls

### DIFF
--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/repositories/BeaconDatasetsRepository.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/repositories/BeaconDatasetsRepository.java
@@ -218,10 +218,18 @@ public class BeaconDatasetsRepository implements DatasetsRepository {
     private DatasetsSearchResponse searchCkan(DatasetSearchQuery query, String ckanAuthorization) {
         var facetsQuery = CkanFacetsQueryBuilder.buildFacetQuery(query);
 
+        String sort_string = query.getSort();
+
+        if (sort_string != null) {
+            if (sort_string.contains("title") && !sort_string.contains("title_string")) {
+                sort_string = sort_string.replace("title", "title_string");
+            }
+        }
+
         var response = ckanQueryApi.packageSearch(
                 query.getQuery(),
                 facetsQuery,
-                query.getSort(),
+                sort_string,
                 query.getRows(),
                 query.getStart(),
                 SELECTED_FACETS,

--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/repositories/CkanDatasetsRepository.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/repositories/CkanDatasetsRepository.java
@@ -32,10 +32,17 @@ public class CkanDatasetsRepository implements DatasetsRepository {
     public DatasetsSearchResponse search(DatasetSearchQuery query, String accessToken) {
         var facetsQuery = CkanFacetsQueryBuilder.buildFacetQuery(query);
 
+        String sort_string = query.getSort();
+        if (sort_string != null) {
+            if (sort_string.contains("title") && !sort_string.contains("title_string")) {
+                sort_string = sort_string.replace("title", "title_string");
+            }
+        }
+
         var response = ckanQueryApi.packageSearch(
                 query.getQuery(),
                 facetsQuery,
-                query.getSort(),
+                sort_string,
                 query.getRows(),
                 query.getStart(),
                 SELECTED_FACETS,


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: 2024 PNED G.I.E. -->

<!-- SPDX-License-Identifier: Apache-2.0 -->

## 🚀 Pull Request Checklist

- **Title:**

This PR replaces "title" by "title_string" in sort string in CKAN API calls

- **Description:**

During testing, it was observed that using the sort string "title asc" for example, does not result in complete alphabetical order. This could be due to the tokenizer used on the title field. CKAN itself sorts on a different field called "title_string".

While we could change this in the front-end, for API compatibility with potential other (non-CKAN) catalogs, I think it's better to change this in here.

- **Testing:**

I found the current tests a bit difficult to understand (I'm not a Java developer, after all) and did not really see a logical unit test to take/modify for this. The test suite passes. Any guidance on this?

- **Checklist:**
  - `[X]` I have checked that my code adheres to the project's style guidelines and that my code is well-commented.
  - `[X]` I have performed self-review of my own code and corrected any misspellings.
  - `[X]` I have made corresponding changes to the documentation (if applicable).
  - `[X]` My changes generate no new warnings or errors.
  - `[ ]` I have added tests that prove my fix is effective or that my feature works.
  - `[ ]` New and existing unit tests pass locally with my changes.
