### PR TITLE
32/fix issues

### DIFF
--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/application/ports/DatasetsRepository.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/application/ports/DatasetsRepository.java
@@ -11,7 +11,6 @@ import java.util.List;
 public interface DatasetsRepository {
 
     List<SearchedDataset> search(List<String> datasetIds,
-            String returnFields,
             String sort,
             Integer rows,
             Integer start,

--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/application/usecases/SearchDatasetsQuery.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/application/usecases/SearchDatasetsQuery.java
@@ -40,7 +40,6 @@ public class SearchDatasetsQuery {
                 .orElse(List.of());
 
         var datasets = repository.search(datasetIds,
-                query.getReturnFields(),
                 query.getSort(),
                 query.getRows(),
                 query.getStart(),

--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/persistence/CkanDatasetIdsCollector.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/persistence/CkanDatasetIdsCollector.java
@@ -38,10 +38,10 @@ public class CkanDatasetIdsCollector implements DatasetIdsCollector {
                 query.getQuery(),
                 facetsQuery,
                 CKAN_IDENTIFIER_FIELD,
-                "",
+                null,
                 CKAN_PAGINATION_MAX_SIZE,
                 0,
-                "",
+                null,
                 accessToken
         );
 

--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/persistence/CkanDatasetsRepository.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/persistence/CkanDatasetsRepository.java
@@ -45,7 +45,6 @@ public class CkanDatasetsRepository implements DatasetsRepository {
 
     @Override
     public List<SearchedDataset> search(List<String> datasetIds,
-            String returnFields,
             String sort,
             Integer rows,
             Integer start,
@@ -71,13 +70,13 @@ public class CkanDatasetsRepository implements DatasetsRepository {
                 .build());
 
         var response = ckanQueryApi.packageSearch(
-                "",
+                null,
                 facetsQuery,
-                returnFields,
+                null,
                 sort,
                 rows,
                 start,
-                "",
+                null,
                 accessToken
         );
 

--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/persistence/CkanFacetsBuilder.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/persistence/CkanFacetsBuilder.java
@@ -41,10 +41,10 @@ public class CkanFacetsBuilder implements FacetsBuilder {
         var response = ckanQueryApi.packageSearch(
                 query.getQuery(),
                 facetsQuery,
-                query.getReturnFields(),
-                query.getSort(),
-                0,
-                query.getStart(),
+                null,
+                null,
+                null,
+                null,
                 selectedFacets,
                 accessToken
         );

--- a/src/main/openapi/discovery.yaml
+++ b/src/main/openapi/discovery.yaml
@@ -166,10 +166,6 @@ components:
           title: Facets
           items:
             $ref: "#/components/schemas/DatasetSearchQueryFacet"
-        returnFields:
-          type: string
-          title: dataset fields to return
-          default: "*"
         sort:
           type: string
           title: Sorting of search results

--- a/src/test/resources/mappings/package_search_facets.json
+++ b/src/test/resources/mappings/package_search_facets.json
@@ -2,7 +2,7 @@
     "priority": 3,
     "request": {
         "method": "GET",
-        "urlPattern": "/api/3/action/enhanced_package_search.*rows=0.*"
+        "urlPattern": "/api/3/action/enhanced_package_search.*facet.field=.*"
     },
     "response": {
         "status": 200,


### PR DESCRIPTION
This includes the changes from the issue 32 and the fix to the issue that occured on dev environment this morning.

The issue was the interaction with the CKAN client. Some parameters were wrong. This could not have been catch during the tests because we currently mock CKAN with Wire Mocks.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix issues with CKAN client interactions by adjusting parameters to null where necessary, removing the 'returnFields' parameter from methods and interfaces, and updating test configurations to align with these changes.

Bug Fixes:
- Fix incorrect parameter handling in CKAN client interactions by replacing certain parameters with null values to resolve issues in the development environment.

Enhancements:
- Remove the 'returnFields' parameter from various methods and interfaces to simplify the CKAN query API interactions.

Tests:
- Update WireMock configuration in 'package_search_facets.json' to reflect changes in CKAN query parameters.

<!-- Generated by sourcery-ai[bot]: end summary -->