### PR TITLE
fix: remove fl attribute from ckan

### DIFF
--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/persistence/CkanDatasetIdsCollector.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/persistence/CkanDatasetIdsCollector.java
@@ -37,7 +37,6 @@ public class CkanDatasetIdsCollector implements DatasetIdsCollector {
         var response = ckanQueryApi.packageSearch(
                 query.getQuery(),
                 facetsQuery,
-                CKAN_IDENTIFIER_FIELD,
                 null,
                 CKAN_PAGINATION_MAX_SIZE,
                 0,

--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/persistence/CkanDatasetsRepository.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/persistence/CkanDatasetsRepository.java
@@ -72,7 +72,6 @@ public class CkanDatasetsRepository implements DatasetsRepository {
         var response = ckanQueryApi.packageSearch(
                 null,
                 facetsQuery,
-                null,
                 sort,
                 rows,
                 start,

--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/persistence/CkanFacetsBuilder.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/persistence/CkanFacetsBuilder.java
@@ -44,7 +44,6 @@ public class CkanFacetsBuilder implements FacetsBuilder {
                 null,
                 null,
                 null,
-                null,
                 selectedFacets,
                 accessToken
         );

--- a/src/main/openapi/ckan.yaml
+++ b/src/main/openapi/ckan.yaml
@@ -30,12 +30,6 @@ paths:
           required: false
           schema:
             type: string
-        - name: fl
-          in: query
-          description: dataset fields to be returned
-          required: false
-          schema:
-            type: string
         - name: sort
           in: query
           description: Sorting of search results

--- a/src/test/resources/mappings/package_search_ids.json
+++ b/src/test/resources/mappings/package_search_ids.json
@@ -2,7 +2,7 @@
     "priority": 3,
     "request": {
         "method": "GET",
-        "urlPattern": "/api/3/action/enhanced_package_search.*fl=identifier.*"
+        "urlPattern": "/api/3/action/enhanced_package_search.*q=.*&rows=.*"
     },
     "response": {
         "status": 200,


### PR DESCRIPTION
CKAN "fl" attribute in PackageSearch seems to not be working well with "identifier". I remove it. The filters should work well now.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Remove the 'fl' attribute from CKAN's PackageSearch to fix issues with the 'identifier' field, improving filter functionality.

Bug Fixes:
- Remove the 'fl' attribute from CKAN's PackageSearch to resolve issues with the 'identifier' field, ensuring filters work correctly.

<!-- Generated by sourcery-ai[bot]: end summary -->