### PR TITLE
fix: filter null identifiers

### DIFF
--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/application/usecases/SearchDatasetsQuery.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/application/usecases/SearchDatasetsQuery.java
@@ -16,7 +16,6 @@ import jakarta.inject.Inject;
 import lombok.RequiredArgsConstructor;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 

--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/persistence/CkanDatasetIdsCollector.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/persistence/CkanDatasetIdsCollector.java
@@ -14,8 +14,8 @@ import jakarta.inject.Inject;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 
 import java.util.List;
+import java.util.Objects;
 
-import static io.github.genomicdatainfrastructure.discovery.datasets.infrastructure.ckan.config.CkanConfiguration.CKAN_IDENTIFIER_FIELD;
 import static io.github.genomicdatainfrastructure.discovery.datasets.infrastructure.ckan.config.CkanConfiguration.CKAN_PAGINATION_MAX_SIZE;
 
 @ApplicationScoped
@@ -49,6 +49,7 @@ public class CkanDatasetIdsCollector implements DatasetIdsCollector {
                 .getResults()
                 .stream()
                 .map(CkanPackage::getIdentifier)
+                .filter(Objects::nonNull)
                 .toList();
 
         return datasetIds;


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the issue of null identifiers being included in the list of dataset IDs by adding a filter to remove null values.

Bug Fixes:
- Filter out null identifiers from the list of dataset IDs collected from CKAN packages.

<!-- Generated by sourcery-ai[bot]: end summary -->