### PR TITLE
feat(ckan): use modified / issued dates from dcat metadata

### DIFF
--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/utils/PackageShowMapper.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/utils/PackageShowMapper.java
@@ -4,25 +4,36 @@
 
 package io.github.genomicdatainfrastructure.discovery.utils;
 
+import static java.util.Optional.*;
+import static java.util.function.Predicate.*;
+
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Objects;
 
-import io.github.genomicdatainfrastructure.discovery.model.*;
-import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.*;
+import io.github.genomicdatainfrastructure.discovery.model.ContactPoint;
+import io.github.genomicdatainfrastructure.discovery.model.DatasetDictionaryEntry;
+import io.github.genomicdatainfrastructure.discovery.model.DatasetRelationEntry;
+import io.github.genomicdatainfrastructure.discovery.model.RetrievedDataset;
+import io.github.genomicdatainfrastructure.discovery.model.RetrievedDistribution;
+import io.github.genomicdatainfrastructure.discovery.model.ValueLabel;
+import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.CkanContactPoint;
+import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.CkanCreator;
+import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.CkanDatasetDictionaryEntry;
+import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.CkanDatasetRelationEntry;
+import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.CkanOrganization;
+import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.CkanPackage;
+import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.CkanResource;
+import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.CkanTag;
+import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.CkanValueLabel;
 import lombok.experimental.UtilityClass;
-
-import static java.util.Optional.ofNullable;
-import static java.util.function.Predicate.not;
-
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 
 @UtilityClass
 public class PackageShowMapper {
 
     private final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern(
-            "yyyy-MM-dd'T'HH:mm:ss.SSSSSS"
-    );
+            "yyyy-MM-dd'T'HH:mm:ss.SSSSSS");
 
     public RetrievedDataset from(CkanPackage ckanPackage) {
         var catalogue = ofNullable(ckanPackage.getOrganization())
@@ -38,8 +49,8 @@ public class PackageShowMapper {
                 .publisherName(ckanPackage.getPublisherName())
                 .catalogue(catalogue)
                 .organization(DatasetOrganizationMapper.from(ckanPackage.getOrganization()))
-                .createdAt(parse(ckanPackage.getMetadataCreated()))
-                .modifiedAt(parse(ckanPackage.getMetadataModified()))
+                .createdAt(offsetDateTimeParse(ckanPackage.getIssued()))
+                .modifiedAt(offsetDateTimeParse(ckanPackage.getModified()))
                 .url(ckanPackage.getUrl())
                 .languages(values(ckanPackage.getLanguage()))
                 .contact(value(ckanPackage.getContactUri()))
@@ -151,9 +162,9 @@ public class PackageShowMapper {
                 .build();
     }
 
-    private LocalDateTime parse(String date) {
+    private OffsetDateTime offsetDateTimeParse(String date) {
         return ofNullable(date)
-                .map(it -> LocalDateTime.parse(it, DATE_FORMATTER))
+                .map(it -> OffsetDateTime.parse(it))
                 .orElse(null);
     }
 
@@ -180,8 +191,6 @@ public class PackageShowMapper {
                 .description(ckanResource.getDescription())
                 .format(value(ckanResource.getFormat()))
                 .uri(ckanResource.getUri())
-                .createdAt(parse(ckanResource.getCreated()))
-                .modifiedAt(parse(ckanResource.getLastModified()))
                 .build();
     }
 

--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/utils/PackagesSearchResponseMapper.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/utils/PackagesSearchResponseMapper.java
@@ -4,29 +4,32 @@
 
 package io.github.genomicdatainfrastructure.discovery.utils;
 
-import io.github.genomicdatainfrastructure.discovery.model.*;
-import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.*;
-import lombok.experimental.UtilityClass;
+import static java.util.Optional.*;
 
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
 import org.apache.commons.lang3.ObjectUtils;
 
-import java.time.format.DateTimeFormatter;
-import java.time.LocalDateTime;
-
-import static java.util.Optional.ofNullable;
+import io.github.genomicdatainfrastructure.discovery.model.DatasetsSearchResponse;
+import io.github.genomicdatainfrastructure.discovery.model.Facet;
+import io.github.genomicdatainfrastructure.discovery.model.FacetGroup;
+import io.github.genomicdatainfrastructure.discovery.model.SearchedDataset;
+import io.github.genomicdatainfrastructure.discovery.model.ValueLabel;
+import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.CkanFacet;
+import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.CkanOrganization;
+import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.CkanPackage;
+import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.CkanValueLabel;
+import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.PackagesSearchResponse;
+import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.PackagesSearchResult;
+import lombok.experimental.UtilityClass;
 
 @UtilityClass
 public class PackagesSearchResponseMapper {
 
     public static final String CKAN_FACET_GROUP = "ckan";
-
-    private final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern(
-            "yyyy-MM-dd'T'HH:mm:ss.SSSSSS"
-    );
 
     public DatasetsSearchResponse from(PackagesSearchResponse response) {
         var count = count(response.getResult());
@@ -77,8 +80,7 @@ public class PackagesSearchResponseMapper {
                 .map(value -> ValueLabel.builder()
                         .value(value.getName())
                         .label(value.getDisplayName())
-                        .build()
-                )
+                        .build())
                 .toList();
 
         return Facet.builder()
@@ -112,14 +114,14 @@ public class PackagesSearchResponseMapper {
                 .themes(values(dataset.getTheme()))
                 .catalogue(catalogue)
                 .organization(DatasetOrganizationMapper.from(dataset.getOrganization()))
-                .modifiedAt(parse(dataset.getMetadataModified()))
-                .createdAt(parse(dataset.getMetadataCreated()))
+                .createdAt(parse(dataset.getIssued()))
+                .modifiedAt(parse(dataset.getModified()))
                 .build();
     }
 
-    private LocalDateTime parse(String date) {
+    private OffsetDateTime parse(String date) {
         return ofNullable(date)
-                .map(it -> LocalDateTime.parse(it, DATE_FORMATTER))
+                .map(OffsetDateTime::parse)
                 .orElse(null);
     }
 

--- a/src/main/openapi/ckan.yaml
+++ b/src/main/openapi/ckan.yaml
@@ -257,6 +257,10 @@ components:
           type: string
         organization:
           $ref: "#/components/schemas/CkanOrganization"
+        issued:
+          type: string
+        modified:
+          type: string
         metadata_created:
           type: string
         metadata_modified:

--- a/src/test/java/io/github/genomicdatainfrastructure/discovery/services/PackageShowMapperTest.java
+++ b/src/test/java/io/github/genomicdatainfrastructure/discovery/services/PackageShowMapperTest.java
@@ -4,7 +4,21 @@
 
 package io.github.genomicdatainfrastructure.discovery.services;
 
-import io.github.genomicdatainfrastructure.discovery.model.*;
+import static java.time.OffsetDateTime.*;
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import io.github.genomicdatainfrastructure.discovery.model.ContactPoint;
+import io.github.genomicdatainfrastructure.discovery.model.DatasetDictionaryEntry;
+import io.github.genomicdatainfrastructure.discovery.model.DatasetOrganization;
+import io.github.genomicdatainfrastructure.discovery.model.DatasetRelationEntry;
+import io.github.genomicdatainfrastructure.discovery.model.RetrievedDataset;
+import io.github.genomicdatainfrastructure.discovery.model.RetrievedDistribution;
+import io.github.genomicdatainfrastructure.discovery.model.ValueLabel;
 import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.CkanContactPoint;
 import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.CkanCreator;
 import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.CkanDatasetDictionaryEntry;
@@ -15,19 +29,11 @@ import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.CkanResou
 import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.CkanTag;
 import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.CkanValueLabel;
 import io.github.genomicdatainfrastructure.discovery.utils.PackageShowMapper;
-import org.junit.jupiter.api.Test;
-
-import java.time.format.DateTimeFormatter;
-import java.util.List;
-
-import static java.time.LocalDateTime.parse;
-import static org.assertj.core.api.Assertions.assertThat;
 
 class PackageShowMapperTest {
 
     private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern(
-            "yyyy-MM-dd'T'HH:mm:ss.SSSSSS"
-    );
+            "yyyy-MM-dd'T'HH:mm:ss.SSSSSS");
 
     @Test
     void accepts_empty_package() {
@@ -69,8 +75,10 @@ class PackageShowMapperTest {
                         .description("description")
                         .imageUrl("https://image.com")
                         .build())
-                .metadataCreated("2024-03-19T13:37:05.472970")
-                .metadataModified("2024-03-19T13:37:05.472970")
+                .issued("2024-07-01T22:00:00+00:00")
+                .modified("2024-07-02T22:00:00+00:00")
+                .metadataCreated("2024-03-19T13:37:05Z")
+                .metadataModified("2024-03-19T13:37:05Z")
                 .tags(List.of(CkanTag.builder()
                         .displayName("key-tag")
                         .id("tag-id")
@@ -114,8 +122,7 @@ class PackageShowMapperTest {
                                 .uri("uri")
                                 .created("2024-03-19T13:37:05.472970")
                                 .lastModified("2024-03-19T13:37:05.472970")
-                                .build()
-                ))
+                                .build()))
                 .contactPoint(List.of(
                         CkanContactPoint.builder()
                                 .contactName("Contact 1")
@@ -125,26 +132,22 @@ class PackageShowMapperTest {
                                 .contactName("Contact 2")
                                 .contactEmail("contact2@example.com")
                                 .contactUri("http://example.com")
-                                .build()
-                ))
+                                .build()))
                 .creator(List.of(
                         CkanCreator.builder()
                                 .creatorName("creatorName")
                                 .creatorIdentifier("creatorIdentifier")
-                                .build()
-                ))
+                                .build()))
                 .datasetRelationships(List.of(
                         CkanDatasetRelationEntry.builder().target("Dataset 1").relation(
                                 "Relation 1").build(),
                         CkanDatasetRelationEntry.builder().target("Dataset 2").relation(
-                                "Relation 2").build()
-                ))
+                                "Relation 2").build()))
                 .dataDictionary(List.of(
                         CkanDatasetDictionaryEntry.builder().name("Entry 1").type("Type 1")
                                 .description("Description 1").build(),
                         CkanDatasetDictionaryEntry.builder().name("Entry 2").type("Type 2")
-                                .description("Description 2").build()
-                ))
+                                .description("Description 2").build()))
                 .build();
 
         var actual = PackageShowMapper.from(ckanPackage);
@@ -157,19 +160,17 @@ class PackageShowMapperTest {
                         ValueLabel.builder()
                                 .value("theme-name")
                                 .label("theme")
-                                .build()
-                ))
+                                .build()))
                 .publisherName("publisherName")
                 .catalogue("organization")
-                .createdAt(parse("2024-03-19T13:37:05.472970", DATE_FORMATTER))
-                .modifiedAt(parse("2024-03-19T13:37:05.472970", DATE_FORMATTER))
+                .createdAt(parse("2024-07-01T22:00:00+00:00"))
+                .modifiedAt(parse("2024-07-02T22:00:00+00:00"))
                 .url("url")
                 .languages(List.of(
                         ValueLabel.builder()
                                 .value("en")
                                 .label("language")
-                                .build()
-                ))
+                                .build()))
                 .contact(ValueLabel.builder()
                         .value("contactUri")
                         .label("contactUri")
@@ -178,14 +179,12 @@ class PackageShowMapperTest {
                         ValueLabel.builder()
                                 .value("1")
                                 .label("version")
-                                .build()
-                ))
+                                .build()))
                 .creators(List.of(
                         ValueLabel.builder()
                                 .label("creatorName")
                                 .value("creatorIdentifier")
-                                .build()
-                ))
+                                .build()))
                 .accessRights(ValueLabel.builder()
                         .value("public")
                         .label("accessRights")
@@ -194,8 +193,7 @@ class PackageShowMapperTest {
                         ValueLabel.builder()
                                 .value("conforms")
                                 .label("conformsTo")
-                                .build()
-                ))
+                                .build()))
                 .organization(DatasetOrganization
                         .builder()
                         .title("organization")
@@ -221,10 +219,7 @@ class PackageShowMapperTest {
                                         .label("format")
                                         .build())
                                 .uri("uri")
-                                .createdAt(parse("2024-03-19T13:37:05.472970", DATE_FORMATTER))
-                                .modifiedAt(parse("2024-03-19T13:37:05.472970", DATE_FORMATTER))
-                                .build()
-                ))
+                                .build()))
                 .contacts(List.of(
                         ContactPoint.builder()
                                 .name("Contact 1")
@@ -234,20 +229,23 @@ class PackageShowMapperTest {
                                 .name("Contact 2")
                                 .email("contact2@example.com")
                                 .uri("http://example.com")
-                                .build()
-                ))
+                                .build()))
                 .datasetRelationships(List.of(
-                        DatasetRelationEntry.builder().relation("Relation 1").target("Dataset 1")
+                        DatasetRelationEntry.builder().relation("Relation 1")
+                                .target("Dataset 1")
                                 .build(),
-                        DatasetRelationEntry.builder().relation("Relation 2").target("Dataset 2")
-                                .build()
-                ))
+                        DatasetRelationEntry.builder().relation("Relation 2")
+                                .target("Dataset 2")
+                                .build()))
                 .dataDictionary(List.of(
-                        DatasetDictionaryEntry.builder().name("Entry 1").type("Type 1").description(
-                                "Description 1").build(),
-                        DatasetDictionaryEntry.builder().name("Entry 2").type("Type 2").description(
-                                "Description 2").build()
-                ))
+                        DatasetDictionaryEntry.builder().name("Entry 1").type("Type 1")
+                                .description(
+                                        "Description 1")
+                                .build(),
+                        DatasetDictionaryEntry.builder().name("Entry 2").type("Type 2")
+                                .description(
+                                        "Description 2")
+                                .build()))
                 .build();
 
         assertThat(actual)

--- a/src/test/java/io/github/genomicdatainfrastructure/discovery/services/PackagesSearchResponseMapperTest.java
+++ b/src/test/java/io/github/genomicdatainfrastructure/discovery/services/PackagesSearchResponseMapperTest.java
@@ -4,24 +4,29 @@
 
 package io.github.genomicdatainfrastructure.discovery.services;
 
-import static java.time.LocalDateTime.parse;
-import static org.assertj.core.api.Assertions.assertThat;
+import static java.time.OffsetDateTime.*;
+import static org.assertj.core.api.Assertions.*;
 
 import java.util.List;
 import java.util.Map;
 
-import io.github.genomicdatainfrastructure.discovery.model.*;
-import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.*;
-import io.github.genomicdatainfrastructure.discovery.utils.PackagesSearchResponseMapper;
 import org.junit.jupiter.api.Test;
 
-import java.time.format.DateTimeFormatter;
+import io.github.genomicdatainfrastructure.discovery.model.DatasetOrganization;
+import io.github.genomicdatainfrastructure.discovery.model.DatasetsSearchResponse;
+import io.github.genomicdatainfrastructure.discovery.model.Facet;
+import io.github.genomicdatainfrastructure.discovery.model.FacetGroup;
+import io.github.genomicdatainfrastructure.discovery.model.SearchedDataset;
+import io.github.genomicdatainfrastructure.discovery.model.ValueLabel;
+import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.CkanFacet;
+import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.CkanOrganization;
+import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.CkanPackage;
+import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.CkanValueLabel;
+import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.PackagesSearchResponse;
+import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.PackagesSearchResult;
+import io.github.genomicdatainfrastructure.discovery.utils.PackagesSearchResponseMapper;
 
 class PackagesSearchResponseMapperTest {
-
-    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern(
-            "yyyy-MM-dd'T'HH:mm:ss.SSSSSS"
-    );
 
     @Test
     void accepts_null_result() {
@@ -30,8 +35,7 @@ class PackagesSearchResponseMapperTest {
                 .build();
 
         var actual = PackagesSearchResponseMapper.from(
-                packagesSearchResponse
-        );
+                packagesSearchResponse);
         var expected = DatasetsSearchResponse.builder()
                 .results(List.of())
                 .facetGroupCount(Map.of())
@@ -40,8 +44,7 @@ class PackagesSearchResponseMapperTest {
                                 .key("ckan")
                                 .label("DCAT-AP")
                                 .facets(List.of())
-                                .build()
-                ))
+                                .build()))
                 .build();
 
         assertThat(actual)
@@ -60,8 +63,7 @@ class PackagesSearchResponseMapperTest {
                 .build();
 
         var actual = PackagesSearchResponseMapper.from(
-                packagesSearchResponse
-        );
+                packagesSearchResponse);
         var expected = DatasetsSearchResponse.builder()
                 .results(List.of())
                 .facetGroupCount(Map.of())
@@ -70,8 +72,7 @@ class PackagesSearchResponseMapperTest {
                                 .key("ckan")
                                 .label("DCAT-AP")
                                 .facets(List.of())
-                                .build()
-                ))
+                                .build()))
                 .build();
 
         assertThat(actual)
@@ -89,8 +90,7 @@ class PackagesSearchResponseMapperTest {
                         .build())
                 .build();
         var actual = PackagesSearchResponseMapper.from(
-                packagesSearchResponse
-        );
+                packagesSearchResponse);
         var expected = DatasetsSearchResponse.builder()
                 .count(1)
                 .facetGroupCount(Map.of("ckan", 1))
@@ -100,8 +100,7 @@ class PackagesSearchResponseMapperTest {
                                 .key("ckan")
                                 .label("DCAT-AP")
                                 .facets(List.of())
-                                .build()
-                ))
+                                .build()))
                 .build();
 
         assertThat(actual)
@@ -119,8 +118,7 @@ class PackagesSearchResponseMapperTest {
                         .build())
                 .build();
         var actual = PackagesSearchResponseMapper.from(
-                packagesSearchResponse
-        );
+                packagesSearchResponse);
         var expected = DatasetsSearchResponse.builder()
                 .count(1)
                 .facetGroupCount(Map.of("ckan", 1))
@@ -130,8 +128,7 @@ class PackagesSearchResponseMapperTest {
                                 .key("ckan")
                                 .label("DCAT-AP")
                                 .facets(List.of())
-                                .build()
-                ))
+                                .build()))
                 .build();
 
         assertThat(actual)
@@ -151,8 +148,7 @@ class PackagesSearchResponseMapperTest {
                         .build())
                 .build();
         var actual = PackagesSearchResponseMapper.from(
-                packagesSearchResponse
-        );
+                packagesSearchResponse);
         var expected = DatasetsSearchResponse.builder()
                 .count(1)
                 .facetGroupCount(Map.of("ckan", 1))
@@ -166,8 +162,7 @@ class PackagesSearchResponseMapperTest {
                                         .label(null)
                                         .values(List.of())
                                         .build()))
-                                .build()
-                ))
+                                .build()))
                 .build();
 
         assertThat(actual)
@@ -187,8 +182,7 @@ class PackagesSearchResponseMapperTest {
                         .build())
                 .build();
         var actual = PackagesSearchResponseMapper.from(
-                packagesSearchResponse
-        );
+                packagesSearchResponse);
         var expected = DatasetsSearchResponse.builder()
                 .count(1)
                 .facetGroupCount(Map.of("ckan", 1))
@@ -202,8 +196,7 @@ class PackagesSearchResponseMapperTest {
                                         .label(null)
                                         .values(List.of())
                                         .build()))
-                                .build()
-                ))
+                                .build()))
                 .build();
 
         assertThat(actual)
@@ -223,8 +216,7 @@ class PackagesSearchResponseMapperTest {
                                                 CkanValueLabel.builder()
                                                         .name("value")
                                                         .displayName("label")
-                                                        .build()
-                                        ))
+                                                        .build()))
                                         .build()))
                         .count(1)
                         .results(List.of(
@@ -246,14 +238,13 @@ class PackagesSearchResponseMapperTest {
                                                         .name("theme")
                                                         .build()))
                                         .publisherName("publisherName")
-                                        .metadataModified("2024-03-19T13:37:05.472970")
-                                        .build()
-                        ))
+                                        .issued("2007-12-03T10:15:30+01:00")
+                                        .modified("2024-09-20T00:00:00+00:00")
+                                        .build()))
                         .build())
                 .build();
         var actual = PackagesSearchResponseMapper.from(
-                packagesSearchResponse
-        );
+                packagesSearchResponse);
         var expected = DatasetsSearchResponse.builder()
                 .count(1)
                 .facetGroupCount(Map.of("ckan", 1))
@@ -274,12 +265,11 @@ class PackagesSearchResponseMapperTest {
                                         ValueLabel.builder()
                                                 .value("theme")
                                                 .label("theme")
-                                                .build()
-                                ))
+                                                .build()))
                                 .catalogue("organization")
-                                .modifiedAt(parse("2024-03-19T13:37:05.472970", DATE_FORMATTER))
-                                .build()
-                ))
+                                .createdAt(parse("2007-12-03T10:15:30+01:00"))
+                                .modifiedAt(parse("2024-09-20T00:00:00+00:00"))
+                                .build()))
                 .facetGroups(List.of(
                         FacetGroup.builder()
                                 .key("ckan")
@@ -291,11 +281,9 @@ class PackagesSearchResponseMapperTest {
                                                 ValueLabel.builder()
                                                         .value("value")
                                                         .label("label")
-                                                        .build()
-                                        ))
+                                                        .build()))
                                         .build()))
-                                .build()
-                ))
+                                .build()))
                 .build();
 
         assertThat(actual)


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: 2024 PNED G.I.E. -->

<!-- SPDX-License-Identifier: Apache-2.0 -->

This PR changes a mapping in the dataset discovery service for CKAN to use the fields "issued" and "modified" as extracted from the DCAT metadata.

Currently, these are mapped to `metadata_created` and `metadata_modifed`, which are derived by CKAN. In practice, it means these dates/times always refer to the latest harvest, not the latest time changes were actually made.

To make sure the discovery service can map it consistently, a few changes have been made to the gdi-userportal extension such that it always harvests timestamps in UTC format. The discovery service output has also been changed to output these. See accompanying PR https://github.com/GenomicDataInfrastructure/gdi-userportal-ckanext-gdi-userportal/pull/90; One user-visible change is that date-time strings will now always be accompanied by timezone information. While this is RFC 3339 compliant and does not break the OpenAPI specification, it might confuse some legacy applications that are not expecting output in this format.

The changes can only be tested in conjunction with the new CKAN gdi-userportal extension.

## 🚀 Pull Request Checklist

- **Title:**

  - `[X]` A brief, descriptive title for the changes.

- **Description:**

  - `[X]` Provide a clear and concise description of your pull request, including the purpose of the changes and the approach you've taken.

- **Context:**

  - `[X]` Why are these changes necessary? What problem do they solve? Link any related issues.

- **Changes:**

  - `[X]` List the major changes you've made, ideally organized by commit or feature.

- **Testing:**

  - `[X]` Describe how the changes have been tested. Include any relevant details about the testing environment and the test cases.

- **Screenshots (if applicable):**

  - `[X]` If your changes are visual, include screenshots to help explain your changes.

- **Additional Information:**

  - `[X]` Add any other information that might be useful for reviewers, such as considerations, discussions, or dependencies.

- **Checklist:**
  - `[X]` I have checked that my code adheres to the project's style guidelines and that my code is well-commented.
  - `[X]` I have performed self-review of my own code and corrected any misspellings.
  - `[X]` I have made corresponding changes to the documentation (if applicable).
  - `[X]` My changes generate no new warnings or errors.
  - `[X]` I have added tests that prove my fix is effective or that my feature works.
  - `[X]` New and existing unit tests pass locally with my changes.
