### PR TITLE
fix: add keywords to searched dataset schema

### DIFF
--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/persistence/CkanDatasetsRepository.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/persistence/CkanDatasetsRepository.java
@@ -10,7 +10,6 @@ import io.github.genomicdatainfrastructure.discovery.remote.ckan.api.CkanQueryAp
 import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.*;
 import io.github.genomicdatainfrastructure.discovery.utils.CkanFacetsQueryBuilder;
 import io.github.genomicdatainfrastructure.discovery.utils.DatasetOrganizationMapper;
-import io.github.genomicdatainfrastructure.discovery.utils.PackageShowMapper;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.apache.commons.lang3.ObjectUtils;

--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/persistence/CkanDatasetsRepository.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/persistence/CkanDatasetsRepository.java
@@ -7,12 +7,10 @@ package io.github.genomicdatainfrastructure.discovery.datasets.infrastructure.ck
 import io.github.genomicdatainfrastructure.discovery.datasets.application.ports.DatasetsRepository;
 import io.github.genomicdatainfrastructure.discovery.model.*;
 import io.github.genomicdatainfrastructure.discovery.remote.ckan.api.CkanQueryApi;
-import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.CkanOrganization;
-import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.CkanPackage;
-import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.CkanValueLabel;
-import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.PackagesSearchResult;
+import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.*;
 import io.github.genomicdatainfrastructure.discovery.utils.CkanFacetsQueryBuilder;
 import io.github.genomicdatainfrastructure.discovery.utils.DatasetOrganizationMapper;
+import io.github.genomicdatainfrastructure.discovery.utils.PackageShowMapper;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.apache.commons.lang3.ObjectUtils;
@@ -104,11 +102,26 @@ public class CkanDatasetsRepository implements DatasetsRepository {
                 .title(dataset.getTitle())
                 .description(dataset.getNotes())
                 .themes(values(dataset.getTheme()))
-                .keywords(values(dataset.getTags()))
+                .keywords(keywords(dataset.getTags()))
                 .catalogue(catalogue)
                 .organization(DatasetOrganizationMapper.from(dataset.getOrganization()))
                 .modifiedAt(parse(dataset.getMetadataModified()))
                 .createdAt(parse(dataset.getMetadataCreated()))
+                .build();
+    }
+
+    private List<ValueLabel> keywords(List<CkanTag> tags) {
+        return ofNullable(tags)
+                .orElseGet(List::of)
+                .stream()
+                .map(this::keyword)
+                .toList();
+    }
+
+    private ValueLabel keyword(CkanTag ckanTag) {
+        return ValueLabel.builder()
+                .label(ckanTag.getDisplayName())
+                .value(ckanTag.getName())
                 .build();
     }
 

--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/persistence/CkanDatasetsRepository.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/persistence/CkanDatasetsRepository.java
@@ -104,6 +104,7 @@ public class CkanDatasetsRepository implements DatasetsRepository {
                 .title(dataset.getTitle())
                 .description(dataset.getNotes())
                 .themes(values(dataset.getTheme()))
+                .keywords(values(dataset.getTags()))
                 .catalogue(catalogue)
                 .organization(DatasetOrganizationMapper.from(dataset.getOrganization()))
                 .modifiedAt(parse(dataset.getMetadataModified()))

--- a/src/main/openapi/discovery.yaml
+++ b/src/main/openapi/discovery.yaml
@@ -241,6 +241,11 @@ components:
           items:
             $ref: "#/components/schemas/ValueLabel"
           title: Themes
+        keywords:
+          type: array
+          items:
+            $ref: "#/components/schemas/ValueLabel"
+          title: Keywords
         catalogue:
           type: string
           title: Catalogue


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Enhance the dataset schema in the OpenAPI discovery document by adding a 'keywords' field to support keyword metadata for datasets.

New Features:
- Add a 'keywords' field to the dataset schema in the OpenAPI discovery document, allowing datasets to include an array of keywords.

<!-- Generated by sourcery-ai[bot]: end summary -->