### PR TITLE
fix: revert OffsetDateTime parsing

### DIFF
--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/persistence/CkanDatasetsRepository.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/persistence/CkanDatasetsRepository.java
@@ -15,7 +15,7 @@ import jakarta.inject.Inject;
 import org.apache.commons.lang3.ObjectUtils;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 
-import java.time.OffsetDateTime;
+import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Objects;
@@ -145,9 +145,9 @@ public class CkanDatasetsRepository implements DatasetsRepository {
                 .orElse(null);
     }
 
-    private OffsetDateTime parse(String date) {
+    private LocalDateTime parse(String date) {
         return ofNullable(date)
-                .map(it -> OffsetDateTime.parse(it, DATE_FORMATTER))
+                .map(it -> LocalDateTime.parse(it, DATE_FORMATTER))
                 .orElse(null);
     }
 

--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/utils/PackageShowMapper.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/utils/PackageShowMapper.java
@@ -7,7 +7,7 @@ package io.github.genomicdatainfrastructure.discovery.utils;
 import static java.util.Optional.*;
 import static java.util.function.Predicate.*;
 
-import java.time.OffsetDateTime;
+import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Objects;
@@ -18,6 +18,10 @@ import lombok.experimental.UtilityClass;
 
 @UtilityClass
 public class PackageShowMapper {
+
+    private final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern(
+            "yyyy-MM-dd'T'HH:mm:ss.SSSSSS"
+    );
 
     public RetrievedDataset from(CkanPackage ckanPackage) {
         var catalogue = ofNullable(ckanPackage.getOrganization())
@@ -33,8 +37,8 @@ public class PackageShowMapper {
                 .publisherName(ckanPackage.getPublisherName())
                 .catalogue(catalogue)
                 .organization(DatasetOrganizationMapper.from(ckanPackage.getOrganization()))
-                .createdAt(offsetDateTimeParse(ckanPackage.getIssued()))
-                .modifiedAt(offsetDateTimeParse(ckanPackage.getModified()))
+                .createdAt(parse(ckanPackage.getMetadataCreated()))
+                .modifiedAt(parse(ckanPackage.getMetadataModified()))
                 .url(ckanPackage.getUrl())
                 .languages(values(ckanPackage.getLanguage()))
                 .contact(value(ckanPackage.getContactUri()))
@@ -146,9 +150,9 @@ public class PackageShowMapper {
                 .build();
     }
 
-    private OffsetDateTime offsetDateTimeParse(String date) {
+    private LocalDateTime parse(String date) {
         return ofNullable(date)
-                .map(it -> OffsetDateTime.parse(it))
+                .map(it -> LocalDateTime.parse(it, DATE_FORMATTER))
                 .orElse(null);
     }
 
@@ -175,6 +179,8 @@ public class PackageShowMapper {
                 .description(ckanResource.getDescription())
                 .format(value(ckanResource.getFormat()))
                 .uri(ckanResource.getUri())
+                .createdAt(parse(ckanResource.getCreated()))
+                .modifiedAt(parse(ckanResource.getLastModified()))
                 .build();
     }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,8 +13,8 @@ quarkus.openapi-generator.codegen.spec.discovery_yaml.additional-model-type-anno
 quarkus.openapi-generator.codegen.spec.discovery_yaml.base-package=io.github.genomicdatainfrastructure.discovery
 quarkus.openapi-generator.codegen.spec.discovery_yaml.import-mappings.File=org.jboss.resteasy.reactive.multipart.FileUpload
 quarkus.openapi-generator.codegen.spec.discovery_yaml.type-mappings.File=FileUpload
-quarkus.openapi-generator.codegen.spec.discovery_yaml.type-mappings.DateTime=OffsetDateTime
-quarkus.openapi-generator.codegen.spec.discovery_yaml.import-mappings.LocalDateTime=java.time.OffsetDateTime
+quarkus.openapi-generator.codegen.spec.discovery_yaml.type-mappings.DateTime=LocalDateTime
+quarkus.openapi-generator.codegen.spec.discovery_yaml.import-mappings.LocalDateTime=java.time.LocalDateTime
 quarkus.openapi-generator.codegen.spec.discovery_yaml.return-response=true
 quarkus.openapi-generator.codegen.spec.ckan_yaml.enable-security-generation=false
 quarkus.openapi-generator.codegen.spec.ckan_yaml.base-package=io.github.genomicdatainfrastructure.discovery.remote.ckan

--- a/src/test/java/io/github/genomicdatainfrastructure/discovery/services/PackageShowMapperTest.java
+++ b/src/test/java/io/github/genomicdatainfrastructure/discovery/services/PackageShowMapperTest.java
@@ -4,7 +4,7 @@
 
 package io.github.genomicdatainfrastructure.discovery.services;
 
-import static java.time.OffsetDateTime.*;
+import static java.time.LocalDateTime.*;
 import static org.assertj.core.api.Assertions.*;
 
 import java.time.format.DateTimeFormatter;
@@ -17,6 +17,10 @@ import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.*;
 import io.github.genomicdatainfrastructure.discovery.utils.PackageShowMapper;
 
 class PackageShowMapperTest {
+
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern(
+            "yyyy-MM-dd'T'HH:mm:ss.SSSSSS"
+    );
 
     @Test
     void accepts_empty_package() {
@@ -58,10 +62,10 @@ class PackageShowMapperTest {
                         .description("description")
                         .imageUrl("https://image.com")
                         .build())
-                .issued("2024-07-01T22:00:00+00:00")
-                .modified("2024-07-02T22:00:00+00:00")
-                .metadataCreated("2024-03-19T13:37:05Z")
-                .metadataModified("2024-03-19T13:37:05Z")
+                .issued("2024-03-19T13:37:05Z")
+                .modified("2024-03-19T13:37:05Z")
+                .metadataCreated("2024-03-19T13:37:05.472970")
+                .metadataModified("2024-03-19T13:37:05.472970")
                 .tags(List.of(CkanTag.builder()
                         .displayName("key-tag")
                         .id("tag-id")
@@ -146,8 +150,8 @@ class PackageShowMapperTest {
                                 .build()))
                 .publisherName("publisherName")
                 .catalogue("organization")
-                .createdAt(parse("2024-07-01T22:00:00+00:00"))
-                .modifiedAt(parse("2024-07-02T22:00:00+00:00"))
+                .createdAt(parse("2024-03-19T13:37:05.472970", DATE_FORMATTER))
+                .modifiedAt(parse("2024-03-19T13:37:05.472970", DATE_FORMATTER))
                 .url("url")
                 .languages(List.of(
                         ValueLabel.builder()
@@ -202,6 +206,8 @@ class PackageShowMapperTest {
                                         .label("format")
                                         .build())
                                 .uri("uri")
+                                .createdAt(parse("2024-03-19T13:37:05.472970", DATE_FORMATTER))
+                                .modifiedAt(parse("2024-03-19T13:37:05.472970", DATE_FORMATTER))
                                 .build()))
                 .contacts(List.of(
                         ContactPoint.builder()


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Revert the parsing of date strings from OffsetDateTime to LocalDateTime across the codebase to fix issues with date handling, ensuring consistency with the expected date format.

Bug Fixes:
- Revert the parsing of date strings from OffsetDateTime to LocalDateTime to address incorrect date handling.

<!-- Generated by sourcery-ai[bot]: end summary -->