### PR TITLE
Deactive keep alive header from rest client

### DIFF
--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/services/BeaconFilteringTermsService.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/services/BeaconFilteringTermsService.java
@@ -14,7 +14,6 @@ import static org.apache.commons.lang3.ObjectUtils.isNotEmpty;
 
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 import io.github.genomicdatainfrastructure.discovery.model.Facet;
-import io.github.genomicdatainfrastructure.discovery.model.FacetGroup;
 import io.github.genomicdatainfrastructure.discovery.model.ValueLabel;
 import io.github.genomicdatainfrastructure.discovery.remote.beacon.api.BeaconQueryApi;
 import io.github.genomicdatainfrastructure.discovery.remote.beacon.model.BeaconFilteringTerm;
@@ -44,23 +43,6 @@ public class BeaconFilteringTermsService {
         this.beaconQueryApi = beaconQueryApi;
     }
 
-    @CacheResult(cacheName = "beacon-facet-group-cache")
-    public FacetGroup listFilteringTerms(String authorization) {
-        var filteringTermsResponse = retrieveNonNullFilteringTermsResponse(authorization);
-
-        var valuesGroupedByFacetId = groupValuesByFacetId(filteringTermsResponse);
-
-        var facetIdsMappedByName = mapFacetNamesByFacetId(filteringTermsResponse);
-
-        var facets = buildFacets(valuesGroupedByFacetId, facetIdsMappedByName);
-
-        return FacetGroup.builder()
-                .key(BEACON_FACET_GROUP)
-                .label("Beacon")
-                .facets(facets)
-                .build();
-    }
-
     @CacheResult(cacheName = "beacon-facets-cache")
     public List<Facet> listFilteringTermList(String authorization) {
         var filteringTermsResponse = retrieveNonNullFilteringTermsResponse(authorization);
@@ -69,9 +51,7 @@ public class BeaconFilteringTermsService {
 
         var facetIdsMappedByName = mapFacetNamesByFacetId(filteringTermsResponse);
 
-        var facets = buildFacets(valuesGroupedByFacetId, facetIdsMappedByName);
-
-        return facets;
+        return buildFacets(valuesGroupedByFacetId, facetIdsMappedByName);
     }
 
     private BeaconFilteringTermsResponseContent retrieveNonNullFilteringTermsResponse(

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -33,6 +33,7 @@ quarkus.rest-client.keycloak_yaml.url=http://localhost:4000
 quarkus.rest-client.keycloak_yaml.beacon_idp_alias=LSAAI
 quarkus.rest-client.beacon_yaml.url=http://localhost:4000
 quarkus.rest-client.beacon_yaml.read-timeout=60000
+quarkus.rest-client.keep-alive-enabled=false
 quarkus.http.cors=true
 quarkus.http.cors.origins=http://localhost:3000
 quarkus.http.port=8080


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Remove the 'listFilteringTerms' method and the 'FacetGroup' schema to streamline the codebase and API definitions, focusing on reducing redundancy and unused components.

Enhancements:
- Remove the method 'listFilteringTerms' from BeaconFilteringTermsService, simplifying the service by eliminating redundant functionality.

Chores:
- Remove the 'FacetGroup' schema from the OpenAPI discovery.yaml file, cleaning up unused or deprecated API components.

<!-- Generated by sourcery-ai[bot]: end summary -->