### PR TITLE
fix: accept date without time

### DIFF
--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/persistence/CkanDatasetsRepository.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/persistence/CkanDatasetsRepository.java
@@ -162,7 +162,11 @@ public class CkanDatasetsRepository implements DatasetsRepository {
         try {
             return OffsetDateTime.parse(date);
         } catch (DateTimeParseException e) {
-            return LocalDateTime.parse(date, DATE_FORMATTER)
+            var dateToParse = date;
+            if (dateToParse.matches("^\\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12]\\d|3[01])$")) {
+                dateToParse += "T00:00:00.000000";
+            }
+            return LocalDateTime.parse(dateToParse, DATE_FORMATTER)
                     .truncatedTo(ChronoUnit.SECONDS)
                     .atOffset(ZoneOffset.UTC);
         }

--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/utils/PackageShowMapper.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/utils/PackageShowMapper.java
@@ -164,7 +164,11 @@ public class PackageShowMapper {
         try {
             return OffsetDateTime.parse(date);
         } catch (DateTimeParseException e) {
-            return LocalDateTime.parse(date, DATE_FORMATTER)
+            var dateToParse = date;
+            if (dateToParse.matches("^\\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12]\\d|3[01])$")) {
+                dateToParse += "T00:00:00.000000";
+            }
+            return LocalDateTime.parse(dateToParse, DATE_FORMATTER)
                     .truncatedTo(ChronoUnit.SECONDS)
                     .atOffset(ZoneOffset.UTC);
         }

--- a/src/test/java/io/github/genomicdatainfrastructure/discovery/services/PackageShowMapperTest.java
+++ b/src/test/java/io/github/genomicdatainfrastructure/discovery/services/PackageShowMapperTest.java
@@ -100,7 +100,7 @@ class PackageShowMapperTest {
                                         .name("pdf")
                                         .build())
                                 .uri("uri")
-                                .created("2025-03-19T13:37:05.472970")
+                                .created("2025-03-19")
                                 .lastModified("2025-03-19T13:37:05Z")
                                 .build()))
                 .contactPoint(List.of(
@@ -194,7 +194,7 @@ class PackageShowMapperTest {
                                 .id("resource_id")
                                 .title("resource_name")
                                 .description("resource_description")
-                                .createdAt(parse("2025-03-19T13:37:05Z"))
+                                .createdAt(parse("2025-03-19T00:00Z"))
                                 .modifiedAt(parse("2025-03-19T13:37:05Z"))
                                 .format(ValueLabel.builder()
                                         .value("pdf")


### PR DESCRIPTION
We were required to accept from CKAN both `issued` and `modified_at`, as they are part of DCAT-AP. The problem now is there are three date format for these fields.

This hotfix will accept all these three format, as we have to decouple the deployment of this component.

The issue GenomicDataInfrastructure/gdi-userportal-ckanext-gdi-userportal/95 on CKAN was created to unify datetime format.

The issue ART-9689 was create in Jira to remove this code duplication.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix date parsing to accept date strings without time components by appending a default time value, ensuring compatibility with multiple date formats as required by DCAT-AP. Update tests to cover the new date handling logic.

Bug Fixes:
- Allow parsing of date strings without time components by appending a default time value, ensuring compatibility with multiple date formats.

Tests:
- Update tests to verify the parsing of date strings without time components, ensuring correct functionality of the new date handling logic.

<!-- Generated by sourcery-ai[bot]: end summary -->