### PR TITLE
Upgrade discovery service for ckanext-dcat 2.0

### DIFF
--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/utils/PackageShowMapper.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/utils/PackageShowMapper.java
@@ -68,7 +68,7 @@ public class PackageShowMapper {
                 .spatial(value(ckanPackage.getSpatialUri()))
                 .distributions(distributions(ckanPackage))
                 .keywords(keywords(ckanPackage))
-                .contacts(contactPoint(ckanPackage.getContactPoint()))
+                .contacts(contactPoint(ckanPackage.getContact()))
                 .datasetRelationships(relations(ckanPackage.getDatasetRelationships()))
                 .dataDictionary(dictionary(ckanPackage.getDataDictionary()))
                 .build();
@@ -103,9 +103,9 @@ public class PackageShowMapper {
 
     private ContactPoint contactPointEntry(CkanContactPoint value) {
         return ContactPoint.builder()
-                .name(value.getContactName())
-                .email(value.getContactEmail())
-                .uri(value.getContactUri())
+                .name(value.getName())
+                .email(value.getEmail())
+                .uri(value.getUri())
                 .build();
     }
 

--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/utils/PackageShowMapper.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/utils/PackageShowMapper.java
@@ -16,22 +16,8 @@ import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Objects;
 
-import io.github.genomicdatainfrastructure.discovery.model.Agent;
-import io.github.genomicdatainfrastructure.discovery.model.ContactPoint;
-import io.github.genomicdatainfrastructure.discovery.model.DatasetDictionaryEntry;
-import io.github.genomicdatainfrastructure.discovery.model.DatasetRelationEntry;
-import io.github.genomicdatainfrastructure.discovery.model.RetrievedDataset;
-import io.github.genomicdatainfrastructure.discovery.model.RetrievedDistribution;
-import io.github.genomicdatainfrastructure.discovery.model.ValueLabel;
-import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.CkanAgent;
-import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.CkanContactPoint;
-import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.CkanDatasetDictionaryEntry;
-import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.CkanDatasetRelationEntry;
-import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.CkanOrganization;
-import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.CkanPackage;
-import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.CkanResource;
-import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.CkanTag;
-import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.CkanValueLabel;
+import io.github.genomicdatainfrastructure.discovery.model.*;
+import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.*;
 import lombok.experimental.UtilityClass;
 
 // TODO review original field and date format on resources

--- a/src/main/openapi/ckan.yaml
+++ b/src/main/openapi/ckan.yaml
@@ -232,7 +232,11 @@ components:
         creator:
           type: array
           items:
-            $ref: "#/components/schemas/CkanCreator"
+            $ref: "#/components/schemas/CkanAgent"
+        publisher:
+          type: array
+          items:
+            $ref: "#/components/schemas/CkanAgent"
         datasetRelationships:
           type: array
           items:
@@ -243,8 +247,6 @@ components:
           items:
             $ref: "#/components/schemas/CkanDatasetDictionaryEntry"
           title: Data Dictionary
-        publisher_name:
-          type: string
         organization:
           $ref: "#/components/schemas/CkanOrganization"
         issued:
@@ -300,16 +302,25 @@ components:
       required:
         - name
         - email
-    CkanCreator:
-      type: object
+    CkanAgent:
       properties:
-        creator_name:
+        name:
           type: string
-        creator_identifier:
+          title: name
+        email:
           type: string
+          title: email
+        url:
+          type: string
+          title: url
+        type:
+          type: string
+          title: type
+        identifier:
+          type: string
+          title: identifier
       required:
-        - creator_name
-        - creator_identifier
+        - name
     CkanDatasetRelationEntry:
       properties:
         relation:

--- a/src/main/openapi/ckan.yaml
+++ b/src/main/openapi/ckan.yaml
@@ -267,8 +267,6 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/CkanValueLabel"
-        contact_uri:
-          type: string
         has_version:
           type: array
           items:

--- a/src/main/openapi/ckan.yaml
+++ b/src/main/openapi/ckan.yaml
@@ -225,7 +225,7 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/CkanTag"
-        contact_point:
+        contact:
           type: array
           items:
             $ref: "#/components/schemas/CkanContactPoint"
@@ -256,6 +256,10 @@ components:
         metadata_created:
           type: string
         metadata_modified:
+          type: string
+        temporal_start:
+          type: string
+        temporal_end:
           type: string
         url:
           type: string
@@ -290,13 +294,13 @@ components:
         - title
     CkanContactPoint:
       properties:
-        contact_name:
+        name:
           type: string
           title: name
-        contact_email:
+        email:
           type: string
           title: email
-        contact_uri:
+        uri:
           type: string
           title: uri
       required:

--- a/src/main/openapi/discovery.yaml
+++ b/src/main/openapi/discovery.yaml
@@ -316,9 +316,6 @@ components:
           items:
             $ref: "#/components/schemas/DatasetDictionaryEntry"
           title: Data Dictionary
-        publisherName:
-          type: string
-          title: Publisher Name
         catalogue:
           type: string
           title: Catalogue
@@ -338,13 +335,14 @@ components:
           items:
             $ref: "#/components/schemas/ValueLabel"
           title: Languages
-        contact:
-          $ref: "#/components/schemas/ValueLabel"
-          title: Contact
         creators:
           type: array
           items:
-            $ref: "#/components/schemas/ValueLabel"
+            $ref: "#/components/schemas/Agent"
+        publishers:
+          type: array
+          items:
+            $ref: "#/components/schemas/Agent"
         hasVersions:
           type: array
           items:
@@ -441,6 +439,26 @@ components:
       required:
         - name
         - email
+    Agent:
+      properties:
+        name:
+          type: string
+          title: name
+        email:
+          type: string
+          title: email
+        url:
+          type: string
+          title: url
+        type:
+          type: string
+          title: type
+        identifier:
+          type: string
+          title: identifier
+      required:
+        - name
+        - email 
     DatasetRelationEntry:
       properties:
         relation:

--- a/src/test/java/io/github/genomicdatainfrastructure/discovery/services/PackageShowMapperTest.java
+++ b/src/test/java/io/github/genomicdatainfrastructure/discovery/services/PackageShowMapperTest.java
@@ -11,23 +11,8 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
-import io.github.genomicdatainfrastructure.discovery.model.Agent;
-import io.github.genomicdatainfrastructure.discovery.model.ContactPoint;
-import io.github.genomicdatainfrastructure.discovery.model.DatasetDictionaryEntry;
-import io.github.genomicdatainfrastructure.discovery.model.DatasetOrganization;
-import io.github.genomicdatainfrastructure.discovery.model.DatasetRelationEntry;
-import io.github.genomicdatainfrastructure.discovery.model.RetrievedDataset;
-import io.github.genomicdatainfrastructure.discovery.model.RetrievedDistribution;
-import io.github.genomicdatainfrastructure.discovery.model.ValueLabel;
-import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.CkanAgent;
-import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.CkanContactPoint;
-import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.CkanDatasetDictionaryEntry;
-import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.CkanDatasetRelationEntry;
-import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.CkanOrganization;
-import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.CkanPackage;
-import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.CkanResource;
-import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.CkanTag;
-import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.CkanValueLabel;
+import io.github.genomicdatainfrastructure.discovery.model.*;
+import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.*;
 import io.github.genomicdatainfrastructure.discovery.utils.PackageShowMapper;
 
 class PackageShowMapperTest {

--- a/src/test/java/io/github/genomicdatainfrastructure/discovery/services/PackageShowMapperTest.java
+++ b/src/test/java/io/github/genomicdatainfrastructure/discovery/services/PackageShowMapperTest.java
@@ -11,8 +11,23 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
-import io.github.genomicdatainfrastructure.discovery.model.*;
-import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.*;
+import io.github.genomicdatainfrastructure.discovery.model.Agent;
+import io.github.genomicdatainfrastructure.discovery.model.ContactPoint;
+import io.github.genomicdatainfrastructure.discovery.model.DatasetDictionaryEntry;
+import io.github.genomicdatainfrastructure.discovery.model.DatasetOrganization;
+import io.github.genomicdatainfrastructure.discovery.model.DatasetRelationEntry;
+import io.github.genomicdatainfrastructure.discovery.model.RetrievedDataset;
+import io.github.genomicdatainfrastructure.discovery.model.RetrievedDistribution;
+import io.github.genomicdatainfrastructure.discovery.model.ValueLabel;
+import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.CkanAgent;
+import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.CkanContactPoint;
+import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.CkanDatasetDictionaryEntry;
+import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.CkanDatasetRelationEntry;
+import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.CkanOrganization;
+import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.CkanPackage;
+import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.CkanResource;
+import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.CkanTag;
+import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.CkanValueLabel;
 import io.github.genomicdatainfrastructure.discovery.utils.PackageShowMapper;
 
 class PackageShowMapperTest {
@@ -31,6 +46,7 @@ class PackageShowMapperTest {
                 .keywords(List.of())
                 .contacts(List.of())
                 .creators(List.of())
+                .publishers(List.of())
                 .datasetRelationships(List.of())
                 .dataDictionary(List.of())
                 .build();
@@ -51,7 +67,6 @@ class PackageShowMapperTest {
                         .displayName("theme")
                         .name("theme-name")
                         .build()))
-                .publisherName("publisherName")
                 .organization(CkanOrganization.builder()
                         .title("organization")
                         .description("description")
@@ -103,20 +118,45 @@ class PackageShowMapperTest {
                                 .created("2025-03-19T13:37:05.472970")
                                 .lastModified("2025-03-19T13:37:05Z")
                                 .build()))
-                .contactPoint(List.of(
+                .contact(List.of(
                         CkanContactPoint.builder()
-                                .contactName("Contact 1")
-                                .contactEmail("contact1@example.com")
+                                .name("Contact 1")
+                                .email("contact1@example.com")
                                 .build(),
                         CkanContactPoint.builder()
-                                .contactName("Contact 2")
-                                .contactEmail("contact2@example.com")
-                                .contactUri("http://example.com")
+                                .name("Contact 2")
+                                .email("contact2@example.com")
+                                .uri("http://example.com")
                                 .build()))
                 .creator(List.of(
-                        CkanCreator.builder()
-                                .creatorName("creatorName")
-                                .creatorIdentifier("creatorIdentifier")
+                        CkanAgent.builder()
+                                .name("creatorName")
+                                .identifier("creatorIdentifier")
+                                .email("email")
+                                .url("url")
+                                .type("type")
+                                .build(),
+                        CkanAgent.builder()
+                                .name("creatorName2")
+                                .identifier("creatorIdentifier2")
+                                .email("email2")
+                                .url("url2")
+                                .type("type2")
+                                .build()))
+                .publisher(List.of(
+                        CkanAgent.builder()
+                                .name("publisherName")
+                                .identifier("publisherIdentifier")
+                                .email("email")
+                                .url("url")
+                                .type("type")
+                                .build(),
+                        CkanAgent.builder()
+                                .name("publisherName2")
+                                .identifier("publisherIdentifier2")
+                                .email("email2")
+                                .url("url2")
+                                .type("type2")
                                 .build()))
                 .datasetRelationships(List.of(
                         CkanDatasetRelationEntry.builder().target("Dataset 1").relation(
@@ -141,7 +181,6 @@ class PackageShowMapperTest {
                                 .value("theme-name")
                                 .label("theme")
                                 .build()))
-                .publisherName("publisherName")
                 .catalogue("organization")
                 .createdAt(parse("2024-07-01T22:00:00+00:00"))
                 .modifiedAt(parse("2024-07-02T22:00:00+00:00"))
@@ -151,19 +190,45 @@ class PackageShowMapperTest {
                                 .value("en")
                                 .label("language")
                                 .build()))
-                .contact(ValueLabel.builder()
-                        .value("contactUri")
-                        .label("contactUri")
-                        .build())
+                .contacts(List.of(ContactPoint.builder()
+                        .name("contactName")
+                        .email("contactEmail")
+                        .uri("contactUri")
+                        .build()))
                 .hasVersions(List.of(
                         ValueLabel.builder()
                                 .value("1")
                                 .label("version")
                                 .build()))
                 .creators(List.of(
-                        ValueLabel.builder()
-                                .label("creatorName")
-                                .value("creatorIdentifier")
+                        Agent.builder()
+                                .name("creatorName")
+                                .identifier("creatorIdentifier")
+                                .email("email")
+                                .url("url")
+                                .type("type")
+                                .build(),
+                        Agent.builder()
+                                .name("creatorName2")
+                                .identifier("creatorIdentifier2")
+                                .email("email2")
+                                .url("url2")
+                                .type("type2")
+                                .build()))
+                .publishers(List.of(
+                        Agent.builder()
+                                .name("publisherName")
+                                .identifier("publisherIdentifier")
+                                .email("email")
+                                .url("url")
+                                .type("type")
+                                .build(),
+                        Agent.builder()
+                                .name("publisherName2")
+                                .identifier("publisherIdentifier2")
+                                .email("email2")
+                                .url("url2")
+                                .type("type2")
                                 .build()))
                 .accessRights(ValueLabel.builder()
                         .value("public")


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: 2024 PNED G.I.E. -->

<!-- SPDX-License-Identifier: Apache-2.0 -->

## 🚀 Pull Request Checklist

- **Title:**

  - `[X]` A brief, descriptive title for the changes.

- **Description:**

This pull requests updates the discovery service for the new DCAT mapping made in ckanext-dcat 2.0; This also prepares us for CKAN 2.11

Note: breaks API compatibility with previous versions! Publisher and Creator are changed compared to previous versions on the user-facing side. Legacy fields like `publisherName` and `contactUrl` have been retired in favor of `foaf:Agent` objects.

  - `[X]` Provide a clear and concise description of your pull request, including the purpose of the changes and the approach you've taken.

- **Context:**

Changes are necessary for compatibility with upstream CKAN.

  - `[X]` Why are these changes necessary? What problem do they solve? Link any related issues.

- **Changes:**

  - `[X]` List the major changes you've made, ideally organized by commit or feature.

- **Testing:**

Tested against fresh version of `gdi-userportal-ckan-docker` with master version of ckanext-dcat, v1.3.1 of gdi-ckanext-fairdatapoint and latest version of ckanext-gdi-userportal.

  - `[X]` Describe how the changes have been tested. Include any relevant details about the testing environment and the test cases.

- **Additional Information:**

As discussed this afternoon, will need to plan the release well ;)

  - `[X]` Add any other information that might be useful for reviewers, such as considerations, discussions, or dependencies.

- **Checklist:**
  - `[X]` I have checked that my code adheres to the project's style guidelines and that my code is well-commented.
  - `[X]` I have performed self-review of my own code and corrected any misspellings.
  - `[X]` I have made corresponding changes to the documentation (if applicable).
  - `[X]` My changes generate no new warnings or errors.
  - `[X]` I have added tests that prove my fix is effective or that my feature works.
  - `[X]` New and existing unit tests pass locally with my changes.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Upgrade the discovery service to support the new DCAT mapping in ckanext-dcat 2.0, replacing legacy fields with `foaf:Agent` objects for publishers and creators, and update OpenAPI specifications and tests accordingly.

New Features:
- Introduce support for `foaf:Agent` objects to represent publishers and creators, replacing legacy fields like `publisherName` and `contactUrl`.

Enhancements:
- Update the discovery service to align with the new DCAT mapping in ckanext-dcat 2.0, preparing for compatibility with CKAN 2.11.

Documentation:
- Update OpenAPI specifications to reflect changes in data models, including the introduction of `Agent` objects and removal of legacy fields.

Tests:
- Modify existing tests to accommodate changes in data models, ensuring compatibility with the updated discovery service.

<!-- Generated by sourcery-ai[bot]: end summary -->