### PR TITLE
fix: replace CKAN dates by DCAT-AP dates in distributions

### DIFF
--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/utils/PackageShowMapper.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/utils/PackageShowMapper.java
@@ -113,8 +113,8 @@ public class PackageShowMapper {
                 .title(ckanResource.getName())
                 .description(ckanResource.getDescription())
                 .format(CkanValueLabelParser.value(ckanResource.getFormat()))
-                .createdAt(CkanDatetimeParser.datetime(ckanResource.getCreated()))
-                .modifiedAt(CkanDatetimeParser.datetime(ckanResource.getLastModified()))
+                .createdAt(CkanDatetimeParser.datetime(ckanResource.getIssuedDate()))
+                .modifiedAt(CkanDatetimeParser.datetime(ckanResource.getModifiedDate()))
                 .accessUrl(ckanResource.getAccessUrl())
                 .downloadUrl(ckanResource.getDownloadUrl())
                 .build();

--- a/src/main/openapi/ckan.yaml
+++ b/src/main/openapi/ckan.yaml
@@ -378,9 +378,9 @@ components:
           type: string
         download_url:
           type: string
-        created:
+        issued_date:
           type: string
-        last_modified:
+        modified_date:
           type: string
       required:
         - id

--- a/src/test/java/io/github/genomicdatainfrastructure/discovery/services/PackageShowMapperTest.java
+++ b/src/test/java/io/github/genomicdatainfrastructure/discovery/services/PackageShowMapperTest.java
@@ -100,8 +100,8 @@ class PackageShowMapperTest {
                                         .build())
                                 .accessUrl("accessUrl")
                                 .downloadUrl("downloadUrl")
-                                .created("2025-03-19")
-                                .lastModified("2025-03-19T13:37:05Z")
+                                .issuedDate("2025-03-19")
+                                .modifiedDate("2025-03-19T13:37:05Z")
                                 .build()))
                 .contact(List.of(
                         CkanContactPoint.builder()


### PR DESCRIPTION
## Summary by Sourcery

Replace CKAN date fields with DCAT-AP date fields in distribution mappings and update corresponding tests to ensure compatibility with DCAT-AP standards.

Bug Fixes:
- Replace CKAN date fields with DCAT-AP date fields in distribution mappings to ensure compatibility with DCAT-AP standards.

Tests:
- Update tests to reflect the changes in date field names from CKAN to DCAT-AP standards.