### PR TITLE
fix: remove content-length from dataset in format endpoint

### DIFF
--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/api/DatasetQueryApiImpl.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/api/DatasetQueryApiImpl.java
@@ -41,7 +41,6 @@ public class DatasetQueryApiImpl implements DatasetQueryApi {
                 .ok(content)
                 .type(type)
                 .header("Content-Disposition", "attachment; filename=\"" + id + "." + format + "\"")
-                .header("Content-Length", content.length())
                 .build();
     }
 


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Remove the 'Content-Length' header from the response in the 'retrieveDatasetInFormat' method to prevent potential issues with incorrect content length calculation.