### PR TITLE
Add language resources

### DIFF
--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/utils/CkanDatetimeParser.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/utils/CkanDatetimeParser.java
@@ -5,6 +5,7 @@
 package io.github.genomicdatainfrastructure.discovery.datasets.infrastructure.ckan.utils;
 
 import lombok.experimental.UtilityClass;
+import org.apache.commons.lang3.StringUtils;
 
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
@@ -21,7 +22,7 @@ public class CkanDatetimeParser {
             "yyyy-MM-dd'T'HH:mm:ss.SSSSSS");
 
     public OffsetDateTime datetime(String date) {
-        if (date == null) {
+        if (StringUtils.isBlank(date)) {
             return null;
         }
 

--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/utils/PackageShowMapper.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/utils/PackageShowMapper.java
@@ -117,6 +117,7 @@ public class PackageShowMapper {
                 .modifiedAt(CkanDatetimeParser.datetime(ckanResource.getModifiedDate()))
                 .accessUrl(ckanResource.getAccessUrl())
                 .downloadUrl(ckanResource.getDownloadUrl())
+                .languages(CkanValueLabelParser.values(ckanResource.getLanguage()))
                 .build();
     }
 

--- a/src/main/openapi/ckan.yaml
+++ b/src/main/openapi/ckan.yaml
@@ -382,6 +382,10 @@ components:
           type: string
         modified_date:
           type: string
+        language:
+          type: array
+          items:
+            $ref: "#/components/schemas/CkanValueLabel"
       required:
         - id
         - name

--- a/src/main/openapi/discovery.yaml
+++ b/src/main/openapi/discovery.yaml
@@ -439,6 +439,10 @@ components:
           type: string
           format: date-time
           title: Distribution modified at
+        languages:
+          type: array
+          items:
+            $ref: "#/components/schemas/ValueLabel"
       required:
         - id
         - title

--- a/src/test/java/io/github/genomicdatainfrastructure/discovery/services/PackageShowMapperTest.java
+++ b/src/test/java/io/github/genomicdatainfrastructure/discovery/services/PackageShowMapperTest.java
@@ -102,6 +102,11 @@ class PackageShowMapperTest {
                                 .downloadUrl("downloadUrl")
                                 .issuedDate("2025-03-19")
                                 .modifiedDate("2025-03-19T13:37:05Z")
+                                .language(List.of(
+                                        CkanValueLabel.builder()
+                                                .displayName("language")
+                                                .name("en")
+                                                .build()))
                                 .build()))
                 .contact(List.of(
                         CkanContactPoint.builder()
@@ -247,6 +252,11 @@ class PackageShowMapperTest {
                                         .build())
                                 .accessUrl("accessUrl")
                                 .downloadUrl("downloadUrl")
+                                .languages(List.of(
+                                        ValueLabel.builder()
+                                                .value("en")
+                                                .label("language")
+                                                .build()))
                                 .build()))
                 .contacts(List.of(
                         ContactPoint.builder()


### PR DESCRIPTION
## Summary by Sourcery

Introduce language resource support in the PackageShowMapper and update OpenAPI specifications to handle multilingual data. Enhance tests to ensure correct parsing of language information.

New Features:
- Add support for language resources in the PackageShowMapper, allowing the mapping of language information from CKAN resources.

Enhancements:
- Update the CKAN and discovery OpenAPI specifications to include language fields, enhancing the API's ability to handle multilingual data.

Tests:
- Extend the PackageShowMapperTest to verify the correct parsing and handling of language information.