### PR TITLE
Revert "chore(deps): update registry.access.redhat.com/ubi9-minimal docker tag to v9.5-1730489338"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2024 PNED G.I.E.
 #
 # SPDX-License-Identifier: Apache-2.0
-FROM registry.access.redhat.com/ubi9-minimal:9.5-1730489338
+FROM registry.access.redhat.com/ubi9-minimal:9.4-1227.1726694542
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \


### PR DESCRIPTION
Reverts GenomicDataInfrastructure/gdi-userportal-dataset-discovery-service#146