### PR TITLE
Revert "chore(deps): update registry.access.redhat.com/ubi9-minimal docker tag to v9.5-1731518200"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -92,7 +92,7 @@ jobs:
           exit-code: "1"
           ignore-unfixed: true
           vuln-type: "os,library"
-          severity: "CRITICAL,HIGH"
+          severity: "CRITICAL"
         env:
           TRIVY_SKIP_DB_UPDATE: true
           TRIVY_SKIP_JAVA_DB_UPDATE: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2024 PNED G.I.E.
 #
 # SPDX-License-Identifier: Apache-2.0
-FROM registry.access.redhat.com/ubi9-minimal:9.5-1731518200
+FROM registry.access.redhat.com/ubi9-minimal:9.4-1227.1726694542
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \


### PR DESCRIPTION
Reverts GenomicDataInfrastructure/gdi-userportal-dataset-discovery-service#148

## Summary by Sourcery

Build:
- Revert the Docker base image to a previous version in the Dockerfile.