### PR TITLE
feat(mapping): Update mapping with missing fields after updating to C…

### DIFF
--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/utils/CkanAgentParser.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/utils/CkanAgentParser.java
@@ -34,6 +34,7 @@ public class CkanAgentParser {
                 .name(agent.getName())
                 .email(agent.getEmail())
                 .url(agent.getUrl())
+                .uri(agent.getUri())
                 .type(agent.getType())
                 .identifier(agent.getIdentifier())
                 .build();

--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/utils/PackageShowMapper.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/utils/PackageShowMapper.java
@@ -77,6 +77,7 @@ public class PackageShowMapper {
                 .name(value.getName())
                 .email(value.getEmail())
                 .uri(value.getUri())
+                .identifier(value.getIdentifier())
                 .build();
     }
 
@@ -134,6 +135,7 @@ public class PackageShowMapper {
                         .type(value.getType())
                         .identifier(value.getIdentifier())
                         .url(value.getUrl())
+                        .uri(value.getUri())
                         .build())
                 .orElse(null);
     }

--- a/src/main/openapi/ckan.yaml
+++ b/src/main/openapi/ckan.yaml
@@ -262,6 +262,9 @@ components:
         uri:
           type: string
           title: uri
+        identifier:
+          type: string
+          title: identifier
       required:
         - name
         - email
@@ -276,6 +279,9 @@ components:
         url:
           type: string
           title: url
+        uri:
+          type: string
+          title: uri
         type:
           type: string
           title: type

--- a/src/main/openapi/discovery.yaml
+++ b/src/main/openapi/discovery.yaml
@@ -473,6 +473,9 @@ components:
         uri:
           type: string
           title: uri
+        identifier:
+          type: string
+          title: identifier
       required:
         - name
         - email
@@ -493,6 +496,9 @@ components:
         identifier:
           type: string
           title: identifier
+        uri:
+          type: string
+          title: uri
       required:
         - name
     DatasetRelationEntry:

--- a/src/test/java/io/github/genomicdatainfrastructure/discovery/services/PackageShowMapperTest.java
+++ b/src/test/java/io/github/genomicdatainfrastructure/discovery/services/PackageShowMapperTest.java
@@ -106,11 +106,13 @@ class PackageShowMapperTest {
                         CkanContactPoint.builder()
                                 .name("Contact 1")
                                 .email("contact1@example.com")
+                                .identifier("contact-identifier-1")
                                 .build(),
                         CkanContactPoint.builder()
                                 .name("Contact 2")
                                 .email("contact2@example.com")
                                 .uri("http://example.com")
+                                .identifier("contact-identifier-2")
                                 .build()
                 ))
                 .creator(List.of(
@@ -120,6 +122,7 @@ class PackageShowMapperTest {
                                 .email("email")
                                 .url("url")
                                 .type("type")
+                                .uri("uri")
                                 .build(),
                         CkanAgent.builder()
                                 .name("creatorName2")
@@ -127,6 +130,7 @@ class PackageShowMapperTest {
                                 .email("email2")
                                 .url("url2")
                                 .type("type2")
+                                .uri("uri2")
                                 .build()
                 ))
                 .publisher(List.of(
@@ -136,6 +140,7 @@ class PackageShowMapperTest {
                                 .email("email")
                                 .url("url")
                                 .type("type")
+                                .uri("uri")
                                 .build(),
                         CkanAgent.builder()
                                 .name("publisherName2")
@@ -143,6 +148,7 @@ class PackageShowMapperTest {
                                 .email("email2")
                                 .url("url2")
                                 .type("type2")
+                                .uri("uri2")
                                 .build()
                 ))
                 .datasetRelationships(List.of(
@@ -190,6 +196,7 @@ class PackageShowMapperTest {
                                 .email("email")
                                 .url("url")
                                 .type("type")
+                                .uri("uri")
                                 .build(),
                         Agent.builder()
                                 .name("creatorName2")
@@ -197,6 +204,7 @@ class PackageShowMapperTest {
                                 .email("email2")
                                 .url("url2")
                                 .type("type2")
+                                .uri("uri2")
                                 .build()
                 ))
                 .publishers(List.of(
@@ -206,6 +214,7 @@ class PackageShowMapperTest {
                                 .email("email")
                                 .url("url")
                                 .type("type")
+                                .uri("uri")
                                 .build(),
                         Agent.builder()
                                 .name("publisherName2")
@@ -213,6 +222,7 @@ class PackageShowMapperTest {
                                 .email("email2")
                                 .url("url2")
                                 .type("type2")
+                                .uri("uri2")
                                 .build()
                 ))
                 .accessRights(ValueLabel.builder()
@@ -256,11 +266,13 @@ class PackageShowMapperTest {
                         ContactPoint.builder()
                                 .name("Contact 1")
                                 .email("contact1@example.com")
+                                .identifier("contact-identifier-1")
                                 .build(),
                         ContactPoint.builder()
                                 .name("Contact 2")
                                 .email("contact2@example.com")
                                 .uri("http://example.com")
+                                .identifier("contact-identifier-2")
                                 .build()
                 ))
                 .datasetRelationships(List.of(


### PR DESCRIPTION
…KAN DCAT EXTENSION 2.1.0

<!-- SPDX-FileCopyrightText: 2024 PNED G.I.E. -->

<!-- SPDX-License-Identifier: Apache-2.0 -->

## 🚀 Pull Request Checklist

- **Title:**

  - `[ ]` Add missing field after upgrade to DCAT extension 2.1.0

- **Description:**

  - `[ ]` After upgrading to DCAT CKAN extension 2.1.0 some fields within contact point and publisher/creator where missing. After this merge this fields will be available

- **Context:**

  - `[ ]` To be much as possible compliant with DCAT AP 3 

- **Changes:**

  - `[ ]` Add URI mapping to Agent(publisher/creator) Add identifier to contactpoint 

- **Testing:**

  - `[ ]`Modified some UT 


- **Checklist:**
  - `[ x]` I have checked that my code adheres to the project's style guidelines and that my code is well-commented.
  - `[ x]` I have performed self-review of my own code and corrected any misspellings.
  - `[ x]` I have made corresponding changes to the documentation (if applicable).
  - `[ x]` My changes generate no new warnings or errors.
  - `[x ]` I have added tests that prove my fix is effective or that my feature works.
  - `[ x]` New and existing unit tests pass locally with my changes.

## Summary by Sourcery

Enhance the mapping by adding missing fields 'uri' and 'identifier' to contact points and agents after upgrading to DCAT CKAN extension 2.1.0. Update YAML configurations and modify unit tests to ensure compliance with DCAT AP 3.

New Features:
- Add URI mapping to Agent (publisher/creator) and identifier to contact point to enhance data representation.

Enhancements:
- Update CKAN and discovery YAML files to include new fields 'uri' and 'identifier' for better compliance with DCAT AP 3.

Tests:
- Modify unit tests to accommodate the new fields 'uri' and 'identifier' in contact points and agents.