### PR TITLE
fix: set request parameter to null when there is no variant

### DIFF
--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/beacon/persistence/BeaconDatasetIdsCollector.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/beacon/persistence/BeaconDatasetIdsCollector.java
@@ -23,6 +23,7 @@ import java.util.Objects;
 
 import static java.util.Optional.ofNullable;
 import static java.util.stream.Collectors.toMap;
+import static org.apache.commons.lang3.ObjectUtils.isEmpty;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 @ApplicationScoped
@@ -47,7 +48,8 @@ public class BeaconDatasetIdsCollector implements DatasetIdsCollector {
 
         var beaconQuery = BeaconIndividualsRequestMapper.from(query);
 
-        if (beaconAuthorization == null || beaconQuery.getQuery().getFilters().isEmpty()) {
+        if (beaconAuthorization == null || (isEmpty(beaconQuery.getQuery().getFilters()) &&
+                isEmpty(beaconQuery.getQuery().getRequestParameters()))) {
             return null;
         }
 

--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/beacon/persistence/BeaconIndividualsRequestMapper.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/beacon/persistence/BeaconIndividualsRequestMapper.java
@@ -61,7 +61,7 @@ public class BeaconIndividualsRequestMapper {
                         .testMode(false)
                         .pagination(new BeaconIndividualsRequestQueryPagination())
                         .filters(beaconFilters)
-                        .requestParameters(requestParameters)
+                        .requestParameters(requestParameters.isEmpty() ? null : requestParameters)
                         .build())
                 .build();
     }

--- a/src/test/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/beacon/BeaconIndividualsRequestMapperTest.java
+++ b/src/test/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/beacon/BeaconIndividualsRequestMapperTest.java
@@ -45,7 +45,7 @@ class BeaconIndividualsRequestMapperTest {
                                         .skip(0)
                                         .build())
                                 .filters(List.of())
-                                .requestParameters(List.of())
+                                .requestParameters(null)
                                 .build())
                         .build());
     }
@@ -71,7 +71,7 @@ class BeaconIndividualsRequestMapperTest {
                                         .skip(0)
                                         .build())
                                 .filters(List.of())
-                                .requestParameters(List.of())
+                                .requestParameters(null)
                                 .build())
                         .build());
     }
@@ -97,7 +97,7 @@ class BeaconIndividualsRequestMapperTest {
                                         .skip(0)
                                         .build())
                                 .filters(List.of())
-                                .requestParameters(List.of())
+                                .requestParameters(null)
                                 .build())
                         .build());
     }


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Set request parameters to null when there are no variants in the BeaconIndividualsRequestMapper.