### PR TITLE
feat(dataset): add HealthDCAT fields to RetrievedDataset and update m…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2024 PNED G.I.E.
 #
 # SPDX-License-Identifier: Apache-2.0
-FROM registry.access.redhat.com/ubi9-minimal:9.5-1741850109
+FROM registry.access.redhat.com/ubi9-minimal:9.5-1742914212
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/src/main/openapi/ckan.yaml
+++ b/src/main/openapi/ckan.yaml
@@ -264,6 +264,8 @@ components:
           type: array
           items:
             type: string
+        trusted_data_holder:
+          type: boolean
         hdab:
           type: array
           items:

--- a/src/main/openapi/ckan.yaml
+++ b/src/main/openapi/ckan.yaml
@@ -315,8 +315,6 @@ components:
           type: integer
         min_typical_age:
           type: integer
-        frequency:
-          type: string
         number_of_records:
           type: integer
         number_of_unique_individuals:

--- a/src/main/openapi/ckan.yaml
+++ b/src/main/openapi/ckan.yaml
@@ -250,6 +250,110 @@ components:
             $ref: "#/components/schemas/CkanResource"
         dcat_type:
           $ref: "#/components/schemas/CkanValueLabel"
+
+        # Bellow are properties from HealthDCAT
+        publisher_note:
+          type: array
+          items:
+            type: string
+        publisher_coverage:
+          type: array
+          items:
+            type: string
+        publisher_type:
+          type: array
+          items:
+            type: string
+        hdab:
+          type: array
+          items:
+            $ref: "#/components/schemas/CkanAgent"
+        spatial_coverage:
+          type: array
+          description: A geographic region that is covered by the dataset.
+          items:
+            $ref: '#/components/schemas/CkanSpatialCoverage'
+        spatial_resolution_in_meters:
+          type: number
+          format: float
+          description: Minimum spatial separation resolvable in a dataset, measured in meters.
+        temporal_coverage:
+          type: array
+          items:
+            $ref: "#/components/schemas/CkanTimeWindow"
+        temporal_resolution:
+          type: string
+        population_coverage:
+          type: array
+          items:
+            type: string
+        retention_period:
+          type: array
+          items:
+            $ref: "#/components/schemas/CkanTimeWindow"
+        purpose:
+          type: array
+          items:
+            type: string
+        legal_basis:
+          type: array
+          items:
+            type: string
+        applicable_legislation:
+          type: array
+          items:
+            type: string
+        health_theme:
+          type: array
+          items:
+            type: string
+        health_category:
+          type: array
+          items:
+            type: string
+        max_typical_age:
+          type: integer
+        min_typical_age:
+          type: integer
+        frequency:
+          type: string
+        number_of_records:
+          type: integer
+        number_of_unique_individuals:
+          type: integer
+        analytics:
+          type: array
+          items:
+            type: string
+        code_values:
+          type: array
+          items:
+            type: string
+        coding_system:
+          type: array
+          items:
+            type: string
+        alternate_identifier:
+          type: array
+          items:
+            type: string
+        version_notes:
+          type: string
+        qualified_relation:
+          type: array
+          items:
+            type: object
+            properties:
+              relation:
+                type: string
+              role:
+                type: string
+              uri:
+                type: string
+        personal_data:
+          type: array
+          items:
+            type: string
       required:
         - id
         - title
@@ -393,3 +497,28 @@ components:
       required:
         - name
         - display_name
+    CkanTimeWindow:
+      properties:
+        start:
+          type: string
+        end:
+          type: string
+    CkanSpatialCoverage:
+      type: object
+      properties:
+        uri:
+          type: string
+          description: URI
+        text:
+          type: string
+          description: Label
+        geom:
+          type: string
+          description: Geometry
+        bbox:
+          type: string
+          description: Bounding Box
+        centroid:
+          type: string
+          description: Centroid
+

--- a/src/main/openapi/discovery.yaml
+++ b/src/main/openapi/discovery.yaml
@@ -450,6 +450,109 @@ components:
           title: Distributions
         dcatType:
           $ref: "#/components/schemas/ValueLabel"
+        # Bellow are properties from HealthDCAT
+        publisher_note:
+          type: array
+          items:
+            type: string
+        publisher_coverage:
+          type: array
+          items:
+            type: string
+        publisher_type:
+          type: array
+          items:
+            type: string
+        hdab:
+          type: array
+          items:
+            $ref: "#/components/schemas/Agent"
+        spatial_coverage:
+          type: array
+          description: A geographic region that is covered by the dataset.
+          items:
+            $ref: '#/components/schemas/SpatialCoverage'
+        spatial_resolution_in_meters:
+          type: number
+          format: float
+          description: Minimum spatial separation resolvable in a dataset, measured in meters.
+        temporal_coverage:
+          type: array
+          items:
+            $ref: "#/components/schemas/TimeWindow"
+        temporal_resolution:
+          type: string
+        population_coverage:
+          type: array
+          items:
+            type: string
+        retention_period:
+          type: array
+          items:
+            $ref: "#/components/schemas/TimeWindow"
+        purpose:
+          type: array
+          items:
+            type: string
+        legal_basis:
+          type: array
+          items:
+            type: string
+        applicable_legislation:
+          type: array
+          items:
+            type: string
+        health_theme:
+          type: array
+          items:
+            type: string
+        health_category:
+          type: array
+          items:
+            type: string
+        max_typical_age:
+          type: integer
+        min_typical_age:
+          type: integer
+        frequency:
+          type: string
+        number_of_records:
+          type: integer
+        number_of_unique_individuals:
+          type: integer
+        analytics:
+          type: array
+          items:
+            type: string
+        code_values:
+          type: array
+          items:
+            type: string
+        coding_system:
+          type: array
+          items:
+            type: string
+        alternate_identifier:
+          type: array
+          items:
+            type: string
+        version_notes:
+          type: string
+        qualified_relation:
+          type: array
+          items:
+            type: object
+            properties:
+              relation:
+                type: string
+              role:
+                type: string
+              uri:
+                type: string
+        personal_data:
+          type: array
+          items:
+            type: string
       required:
         - id
         - title
@@ -566,6 +669,32 @@ components:
         - name
         - type
         - description
+    TimeWindow:
+      properties:
+        start:
+          type: string
+          format: date-time
+        end:
+          type: string
+          format: date-time
+    SpatialCoverage:
+      type: object
+      properties:
+        uri:
+          type: string
+          description: URI
+        text:
+          type: string
+          description: Label
+        geom:
+          type: string
+          description: Geometry
+        bbox:
+          type: string
+          description: Bounding Box
+        centroid:
+          type: string
+          description: Centroid
     Filter:
       properties:
         source:

--- a/src/main/openapi/discovery.yaml
+++ b/src/main/openapi/discovery.yaml
@@ -451,42 +451,44 @@ components:
         dcatType:
           $ref: "#/components/schemas/ValueLabel"
         # Below are properties from HealthDCAT
-        publisher_note:
+        publisherNote:
           type: array
           items:
             type: string
-        publisher_coverage:
+        publisherCoverage:
           type: array
           items:
             type: string
-        publisher_type:
+        publisherType:
           type: array
           items:
             type: string
+        trustedDataHolder:
+          type: boolean
         hdab:
           type: array
           items:
             $ref: "#/components/schemas/Agent"
-        spatial_coverage:
+        spatialCoverage:
           type: array
           description: A geographic region that is covered by the dataset.
           items:
             $ref: '#/components/schemas/SpatialCoverage'
-        spatial_resolution_in_meters:
+        spatialResolutionInMeters:
           type: number
           format: float
           description: Minimum spatial separation resolvable in a dataset, measured in meters.
-        temporal_coverage:
+        temporalCoverage:
           type: array
           items:
             $ref: "#/components/schemas/TimeWindow"
-        temporal_resolution:
+        temporalResolution:
           type: string
-        population_coverage:
+        populationCoverage:
           type: array
           items:
             type: string
-        retention_period:
+        retentionPeriod:
           type: array
           items:
             $ref: "#/components/schemas/TimeWindow"
@@ -494,49 +496,49 @@ components:
           type: array
           items:
             type: string
-        legal_basis:
+        legalBasis:
           type: array
           items:
             type: string
-        applicable_legislation:
+        applicableLegislation:
           type: array
           items:
             type: string
-        health_theme:
+        healthTheme:
           type: array
           items:
             type: string
-        health_category:
+        healthCategory:
           type: array
           items:
             type: string
-        max_typical_age:
+        maxTypicalAge:
           type: integer
-        min_typical_age:
+        minTypicalAge:
           type: integer
-        number_of_records:
+        numberOfRecords:
           type: integer
-        number_of_unique_individuals:
+        numberOfUniqueIndividuals:
           type: integer
         analytics:
           type: array
           items:
             type: string
-        code_values:
+        codeValues:
           type: array
           items:
             type: string
-        coding_system:
+        codingSystem:
           type: array
           items:
             type: string
-        alternate_identifier:
+        alternateIdentifier:
           type: array
           items:
             type: string
-        version_notes:
+        versionNotes:
           type: string
-        qualified_relation:
+        qualifiedRelation:
           type: array
           items:
             type: object
@@ -547,7 +549,7 @@ components:
                 type: string
               uri:
                 type: string
-        personal_data:
+        personalData:
           type: array
           items:
             type: string

--- a/src/main/openapi/discovery.yaml
+++ b/src/main/openapi/discovery.yaml
@@ -514,8 +514,6 @@ components:
           type: integer
         min_typical_age:
           type: integer
-        frequency:
-          type: string
         number_of_records:
           type: integer
         number_of_unique_individuals:

--- a/src/test/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/mapper/CkanDatasetsMapperTest.java
+++ b/src/test/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/mapper/CkanDatasetsMapperTest.java
@@ -220,6 +220,7 @@ class CkanDatasetsMapperTest {
                     .publisherNote(List.of(
                             "Health-RI is the Dutch health care initiative to build an integrated health data infrastructure for research and innovation."))
                     .publisherType(List.of("http://example.com/publisherType/undefined"))
+                    .trustedDataHolder(true)
                     .purpose(List.of("https://w3id.org/dpv#AcademicResearch"))
                     .qualifiedRelation(List.of(
                             RetrievedDatasetQualifiedRelationInner.builder()
@@ -362,6 +363,7 @@ class CkanDatasetsMapperTest {
                 .publisherNote(List.of(
                         "Health-RI is the Dutch health care initiative to build an integrated health data infrastructure for research and innovation."))
                 .publisherType(List.of("http://example.com/publisherType/undefined"))
+                .trustedDataHolder(true)
                 .purpose(List.of("https://w3id.org/dpv#AcademicResearch"))
                 .retentionPeriod(List.of(
                         CkanTimeWindow.builder()

--- a/src/test/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/mapper/CkanDatasetsMapperTest.java
+++ b/src/test/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/mapper/CkanDatasetsMapperTest.java
@@ -45,6 +45,11 @@ class CkanDatasetsMapperTest {
                     .publishers(List.of())
                     .datasetRelationships(List.of())
                     .dataDictionary(List.of())
+                    .hdab(List.of())
+                    .qualifiedRelation(List.of())
+                    .retentionPeriod(List.of())
+                    .spatialCoverage(List.of())
+                    .temporalCoverage(List.of())
                     .build();
 
             assertThat(actual)
@@ -186,6 +191,62 @@ class CkanDatasetsMapperTest {
                                             "Description 2")
                                     .build()
                     ))
+                    .alternateIdentifier(List.of("internalURI:admsIdentifier0"))
+                    .analytics(List.of("http://example.com/analytics"))
+                    .applicableLegislation(List.of("http://data.europa.eu/eli/reg/2022/868/oj"))
+                    .codeValues(List.of("http://example.com/code1", "http://example.com/code2"))
+                    .codingSystem(List.of("http://example.com/codingSystem"))
+                    .hdab(List.of(Agent.builder()
+                            .name("EU Health Data Access Body")
+                            .email("hdab@example.com")
+                            .url("https://www.example.com/hdab")
+                            .build()))
+                    .healthCategory(List.of("Genomics", "Medical Imaging",
+                            "Electronic Health Records"))
+                    .healthTheme(List.of(
+                            "http://www.wikidata.org/entity/Q58624061",
+                            "http://www.wikidata.org/entity/Q7907952"))
+                    .legalBasis(List.of("https://w3id.org/dpv#Consent"))
+                    .maxTypicalAge(100)
+                    .minTypicalAge(0)
+                    .numberOfRecords(123456789)
+                    .numberOfUniqueIndividuals(123456789)
+                    .personalData(List.of(
+                            "https://w3id.org/dpv/dpv-pd#Age",
+                            "https://w3id.org/dpv/dpv-pd#Gender",
+                            "https://w3id.org/dpv/dpv-pd#HealthRecord"))
+                    .populationCoverage(List.of(
+                            "This example includes a very non-descript population"))
+                    .publisherNote(List.of(
+                            "Health-RI is the Dutch health care initiative to build an integrated health data infrastructure for research and innovation."))
+                    .publisherType(List.of("http://example.com/publisherType/undefined"))
+                    .purpose(List.of("https://w3id.org/dpv#AcademicResearch"))
+                    .qualifiedRelation(List.of(
+                            RetrievedDatasetQualifiedRelationInner.builder()
+                                    .relation("http://example.com/dataset/3.141592")
+                                    .role("https://w3id.org/dpv#AcademicResearchRole")
+                                    .uri("https://w3id.org/dpv#AcademicResearchUri")
+                                    .build()))
+                    .retentionPeriod(List.of(
+                            TimeWindow.builder()
+                                    .start(parse("2024-07-01T22:00:00Z"))
+                                    .end(parse("2024-07-02T22:00:00Z"))
+                                    .build()))
+                    .spatialCoverage(List.of(
+                            SpatialCoverage.builder()
+                                    .uri("https://www.geonames.org/2745912/utrecht.html")
+                                    .text("Utrecht, Netherlands")
+                                    .geom("POLYGON((5.045 52.090, 5.145 52.090, 5.145 52.150, 5.045 52.150, 5.045 52.090))")
+                                    .bbox("5.045,52.090,5.145,52.150")
+                                    .centroid("5.095,52.120")
+                                    .build()))
+                    .spatialResolutionInMeters(10.0f)
+                    .temporalCoverage(List.of(
+                            TimeWindow.builder()
+                                    .start(parse("2024-07-01T22:00:00+00:00"))
+                                    .end(parse("2024-07-02T22:00:00+00:00"))
+                                    .build()))
+                    .temporalResolution("P1D")
                     .build();
 
             assertThat(actual)
@@ -274,6 +335,72 @@ class CkanDatasetsMapperTest {
                         CkanDatasetDictionaryEntry.builder().name("Entry 2").type("Type 2")
                                 .description("Description 2").build()
                 ))
+                .healthTheme(List.of("http://www.wikidata.org/entity/Q58624061",
+                        "http://www.wikidata.org/entity/Q7907952"))
+                .healthCategory(List.of("Genomics", "Medical Imaging", "Electronic Health Records"))
+                .legalBasis(List.of("https://w3id.org/dpv#Consent"))
+                .hdab(List.of(
+                        CkanAgent.builder()
+                                .name("EU Health Data Access Body")
+                                .url("https://www.example.com/hdab")
+                                .email("hdab@example.com")
+                                .build()
+                )
+                )
+                .minTypicalAge(0)
+                .maxTypicalAge(100)
+                .numberOfRecords(123456789)
+                .numberOfUniqueIndividuals(123456789)
+                .personalData(List.of("https://w3id.org/dpv/dpv-pd#Age",
+                        "https://w3id.org/dpv/dpv-pd#Gender",
+                        "https://w3id.org/dpv/dpv-pd#HealthRecord"))
+                .populationCoverage(List.of("This example includes a very non-descript population"))
+                .personalData(List.of("https://w3id.org/dpv/dpv-pd#Age",
+                        "https://w3id.org/dpv/dpv-pd#Gender",
+                        "https://w3id.org/dpv/dpv-pd#HealthRecord"))
+                .populationCoverage(List.of("This example includes a very non-descript population"))
+                .publisherNote(List.of(
+                        "Health-RI is the Dutch health care initiative to build an integrated health data infrastructure for research and innovation."))
+                .publisherType(List.of("http://example.com/publisherType/undefined"))
+                .purpose(List.of("https://w3id.org/dpv#AcademicResearch"))
+                .retentionPeriod(List.of(
+                        CkanTimeWindow.builder()
+                                .start("2024-07-01T22:00:00+00:00")
+                                .end("2024-07-02T22:00:00+00:00")
+                                .build()
+                ))
+                .codeValues(List.of("http://example.com/code1", "http://example.com/code2"))
+                .analytics(List.of("http://example.com/analytics"))
+                .codingSystem(List.of("http://example.com/codingSystem"))
+                .applicableLegislation(List.of("http://data.europa.eu/eli/reg/2022/868/oj"))
+                .qualifiedRelation(List.of(
+                        CkanPackageQualifiedRelationInner.builder()
+                                .role("https://w3id.org/dpv#AcademicResearchRole")
+                                .relation("http://example.com/dataset/3.141592")
+                                .uri("https://w3id.org/dpv#AcademicResearchUri")
+                                .build()
+                ))
+                .temporalStart("2024-07-12T22:00:00+00:00")
+                .temporalEnd("2024-07-13T22:00:00+00:00")
+                .temporalCoverage(List.of(
+                        CkanTimeWindow.builder()
+                                .start("2024-07-01T22:00:00+00:00")
+                                .end("2024-07-02T22:00:00+00:00")
+                                .build()
+                ))
+                .temporalResolution("P1D")
+                .alternateIdentifier(List.of("internalURI:admsIdentifier0"))
+                .spatialCoverage(List.of(
+                        CkanSpatialCoverage.builder()
+                                .uri("https://www.geonames.org/2745912/utrecht.html")
+                                .text("Utrecht, Netherlands")
+                                .geom("POLYGON((5.045 52.090, 5.145 52.090, 5.145 52.150, 5.045 52.150, 5.045 52.090))")
+                                .bbox("5.045,52.090,5.145,52.150")
+                                .centroid("5.095,52.120")
+                                .build()
+                ))
+                .spatialResolutionInMeters(10.0f)
+                .alternateIdentifier(List.of("internalURI:admsIdentifier0"))
                 .build();
     }
 


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: 2025 Health-RI. -->

<!-- SPDX-License-Identifier: Apache-2.0 -->

## 🚀 Pull Request Checklist

- **Title:**

  - [x] `feat(dataset): add HealthDCAT fields to RetrievedDataset and update mapping test`

- **Description:**

  - [x] This pull request introduces support for several HealthDCAT fields in the `RetrievedDataset` model. These fields are now also mapped in `CkanDatasetsMapper` and validated through updated unit tests.

- **Context:**

  - [x] These changes are necessary to support the extended HealthDCAT specification as required by the GDI project. This allows for richer metadata such as health themes, population coverage, legal basis, and spatial/temporal coverage to be included in the dataset model.
  
    Related: _[Insert issue number or link if tracked in an issue tracker]_

- **Changes:**

  - [x] Extended `RetrievedDataset` with HealthDCAT fields (e.g., `healthTheme`, `legalBasis`, `personalData`, etc.)
  - [x] Updated `CkanDatasetsMapper` to populate new fields from CKAN metadata
  - [x] Enhanced unit test `given_ckanPackage_should_be_mapped_to_expected_values()` to cover the new fields

- **Testing:**

  - [x] Added and verified expected values in `RetrievedDatasetTest` to include new fields
  - [x] Ran full test suite locally to ensure no regressions
  - Environment: Java 17, JUnit 5, Maven

- **Screenshots (if applicable):**

  - [ ] _Not applicable – no UI changes_

- **Additional Information:**

  - [x] HealthDCAT fields follow the current GDI metadata specification. Field mappings are based on provided examples and metadata alignment with CKAN/FDP.

- **Checklist:**
  - [x] I have checked that my code adheres to the project's style guidelines and that my code is well-commented.
  - [x] I have performed self-review of my own code and corrected any misspellings.
  - [x] I have made corresponding changes to the documentation (if applicable).
  - [x] My changes generate no new warnings or errors.
  - [x] I have added tests that prove my fix is effective or that my feature works.
  - [x] New and existing unit tests pass locally with my changes.

## Summary by Sourcery

Add comprehensive HealthDCAT metadata fields to dataset models and mappers to support richer dataset descriptions for health research

New Features:
- Introduced extensive HealthDCAT metadata fields for datasets, including health themes, population coverage, legal basis, and spatial/temporal metadata

Enhancements:
- Extended OpenAPI specifications to include new HealthDCAT-specific metadata fields
- Updated dataset mapping to support more detailed health-related dataset information

Tests:
- Enhanced unit tests to validate mapping of new HealthDCAT metadata fields
- Updated test cases to cover additional dataset attributes