### PR TITLE
fix: show correct count value when multiple datasets share the same identifier

### DIFF
--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/application/usecases/SearchDatasetsQuery.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/application/usecases/SearchDatasetsQuery.java
@@ -52,7 +52,7 @@ public class SearchDatasetsQuery {
 
         return DatasetsSearchResponse
                 .builder()
-                .count(datasetIdsByRecordCount.size())
+                .count(enhancedDatasets.size())
                 .results(enhancedDatasets)
                 .build();
     }

--- a/src/test/java/io/github/genomicdatainfrastructure/discovery/datasets/application/usecases/SearchDatasetsQueryTest.java
+++ b/src/test/java/io/github/genomicdatainfrastructure/discovery/datasets/application/usecases/SearchDatasetsQueryTest.java
@@ -77,7 +77,7 @@ class SearchDatasetsQueryTest {
 
         var response = underTest.execute(query, accessToken);
 
-        assertEquals(1, response.getCount());
+        assertEquals(2, response.getCount());
         assertEquals("id1", response.getResults().getFirst().getIdentifier());
         assertEquals(10, response.getResults().getFirst().getRecordsCount());
 

--- a/src/test/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/quarkus/DatasetSearchTest.java
+++ b/src/test/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/quarkus/DatasetSearchTest.java
@@ -78,7 +78,7 @@ class DatasetSearchTest extends BaseTest {
                 .post("/api/v1/datasets/search")
                 .then()
                 .statusCode(200)
-                .body("count", equalTo(1))
+                .body("count", equalTo(3))
                 .body("results[0].identifier", equalTo("27866022694497975"))
                 .body("results[0].recordsCount", equalTo(64));
     }


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: 2024 PNED G.I.E. -->

<!-- SPDX-License-Identifier: Apache-2.0 -->

## 🚀 Pull Request Checklist

- **Title:**
  - Fix count bug
- **Description:**
  - Fix a bug where the shown count did not match the number of results
- **Context:**
  - We ran into an issue where the count was `1`, but there were three results. The underlying issue was the three datasets sharing the same identifier.
- **Changes:**
  - Instead of using the datasetsIdsByRecordCount, it now uses the enhancedDataset count to reflect the actual number of results.
- **Testing:**
  - Unit tests were updated to accept the new changes.

- **Screenshots (if applicable):**

  - `[ ]` If your changes are visual, include screenshots to help explain your changes.

- **Additional Information:**
  -  It seems like the CKAN queries will _always_ have a `null` value for the count, so this logic is only being used in the Beacon queries. @brunopacheco1 would it make sense to refactor this code into CKAN and Beacon specific implementations?

- **Checklist:**
  - [X] I have checked that my code adheres to the project's style guidelines and that my code is well-commented.
  - [X] I have performed self-review of my own code and corrected any misspellings.
  - [X] I have made corresponding changes to the documentation (if applicable).
  - [X] My changes generate no new warnings or errors.
  - `[ ]` I have added tests that prove my fix is effective or that my feature works.
  - [X] New and existing unit tests pass locally with my changes.

## Summary by Sourcery

Fix the dataset search count to accurately reflect the number of results when multiple datasets share the same identifier

Bug Fixes:
- Correct the count calculation in dataset search to use the actual number of enhanced datasets instead of unique dataset IDs

Tests:
- Updated unit tests to verify the correct count calculation for datasets with shared identifiers