### PR TITLE
fix: avoid nullpointer when gvariants return empty results

### DIFF
--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/beacon/persistence/BeaconGVariantsRequestMapper.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/beacon/persistence/BeaconGVariantsRequestMapper.java
@@ -50,7 +50,7 @@ public class BeaconGVariantsRequestMapper {
     }
 
     private static GVariantsSearchResponse mapResultSetToVariant(BeaconResultSet resultSet) {
-        if (resultSet == null) {
+        if (resultSet == null || resultSet.getResults() == null) {
             return null;
         }
         GVariantsSearchResponse variant = new GVariantsSearchResponse();


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Return null when result set or its results are null to avoid NullPointerException in BeaconGVariantsRequestMapper.mapResultSetToVariant