### PR TITLE
fix(openapi): avoid complex objects in access service (unsupported fo…

### DIFF
--- a/src/main/openapi/ckan.yaml
+++ b/src/main/openapi/ckan.yaml
@@ -564,7 +564,8 @@ components:
             type: object
             properties:
               access_rights:
-                $ref: "#/components/schemas/CkanValueLabel"
+                type: string
+                format: uri
               applicable_legislation:
                 type: array
                 items:
@@ -573,7 +574,8 @@ components:
               conforms_to:
                 type: array
                 items:
-                  $ref: "#/components/schemas/CkanValueLabel"
+                  type: string
+                  format: uri
               contact:
                 $ref: "#/components/schemas/CkanContactPoint"
               creator:
@@ -583,7 +585,7 @@ components:
               rights:
                 type: array
                 items:
-                  $ref: "#/components/schemas/CkanValueLabel"
+                  type: string
               description:
                 type: string
               endpoint_description:
@@ -596,7 +598,8 @@ components:
               format:
                 type: array
                 items:
-                  $ref: "#/components/schemas/CkanValueLabel"
+                  type: string
+                  format: uri
               identifier:
                 type: string
               keyword:
@@ -610,7 +613,8 @@ components:
               language:
                 type: array
                 items:
-                  $ref: "#/components/schemas/CkanValueLabel"
+                  type: string
+                  format: uri
               license:
                 type: string
               modified:
@@ -624,7 +628,8 @@ components:
               theme:
                 type: array
                 items:
-                  $ref: "#/components/schemas/CkanValueLabel"
+                  type: string
+                  format: uri
               uri:
                 type: string
                 format: uri

--- a/src/main/openapi/discovery.yaml
+++ b/src/main/openapi/discovery.yaml
@@ -714,7 +714,8 @@ components:
             type: object
             properties:
               accessRights:
-                $ref: "#/components/schemas/ValueLabel"
+                type: string
+                format: uri
               applicableLegislation:
                 type: array
                 items:
@@ -723,7 +724,8 @@ components:
               conformsTo:
                 type: array
                 items:
-                  $ref: "#/components/schemas/ValueLabel"
+                  type: string
+                  format: uri
               contact:
                 $ref: "#/components/schemas/ContactPoint"
               creator:
@@ -733,7 +735,7 @@ components:
               rights:
                 type: array
                 items:
-                  $ref: "#/components/schemas/ValueLabel"
+                  type: string
               description:
                 type: string
               endpointDescription:
@@ -746,7 +748,8 @@ components:
               format:
                 type: array
                 items:
-                  $ref: "#/components/schemas/ValueLabel"
+                  type: string
+                  format: uri
               id:
                 type: string
                 title: Data service internal ID
@@ -761,7 +764,8 @@ components:
               languages:
                 type: array
                 items:
-                  $ref: "#/components/schemas/ValueLabel"
+                  type: string
+                  format: uri
               license:
                 type: string
               modified:
@@ -776,7 +780,8 @@ components:
               theme:
                 type: array
                 items:
-                  $ref: "#/components/schemas/ValueLabel"
+                  type: string
+                  format: uri
               uri:
                 type: string
                 format: uri


### PR DESCRIPTION
…r now)

<!-- SPDX-FileCopyrightText: 2024 PNED G.I.E. -->

<!-- SPDX-License-Identifier: Apache-2.0 -->

## 🚀 Pull Request Checklist

- **Title:**

  - `[ ]` A brief, descriptive title for the changes.

- **Description:**

  - `[ ]` Provide a clear and concise description of your pull request, including the purpose of the changes and the approach you've taken.

- **Context:**

  - `[ ]` Why are these changes necessary? What problem do they solve? Link any related issues.

- **Changes:**

  - `[ ]` List the major changes you've made, ideally organized by commit or feature.

- **Testing:**

  - `[ ]` Describe how the changes have been tested. Include any relevant details about the testing environment and the test cases.

- **Screenshots (if applicable):**

  - `[ ]` If your changes are visual, include screenshots to help explain your changes.

- **Additional Information:**

  - `[ ]` Add any other information that might be useful for reviewers, such as considerations, discussions, or dependencies.

- **Checklist:**
  - `[ ]` I have checked that my code adheres to the project's style guidelines and that my code is well-commented.
  - `[ ]` I have performed self-review of my own code and corrected any misspellings.
  - `[ ]` I have made corresponding changes to the documentation (if applicable).
  - `[ ]` My changes generate no new warnings or errors.
  - `[ ]` I have added tests that prove my fix is effective or that my feature works.
  - `[ ]` New and existing unit tests pass locally with my changes.

## Summary by Sourcery

Simplify the access service's OpenAPI definitions by removing unsupported complex object references and using primitive string types with URI format for metadata fields

Bug Fixes:
- Remove references to complex CkanValueLabel schema in ckan.yaml
- Remove references to complex ValueLabel schema in discovery.yaml

Enhancements:
- Define metadata fields (e.g., access_rights, conforms_to, format, languages, theme, uri) as string types with URI format where applicable to flatten schemas