### PR TITLE
feat: group filters by key

### DIFF
--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/filters/application/usecases/RetrieveFiltersQuery.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/filters/application/usecases/RetrieveFiltersQuery.java
@@ -5,6 +5,8 @@
 package io.github.genomicdatainfrastructure.discovery.filters.application.usecases;
 
 import io.github.genomicdatainfrastructure.discovery.filters.application.ports.FilterBuilder;
+import io.github.genomicdatainfrastructure.discovery.filters.infrastructure.quarkus.DatasetsConfig;
+import io.github.genomicdatainfrastructure.discovery.filters.infrastructure.quarkus.DatasetsConfig.FilterGroup;
 import io.github.genomicdatainfrastructure.discovery.model.Filter;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Instance;
@@ -16,11 +18,14 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
+import static java.util.Optional.ofNullable;
+
 @ApplicationScoped
 @RequiredArgsConstructor(onConstructor = @__(@Inject))
 public class RetrieveFiltersQuery {
 
     private final Instance<FilterBuilder> filterBuilders;
+    private final DatasetsConfig datasetsConfig;
 
     public List<Filter> execute(String accessToken) {
         return filterBuilders
@@ -28,6 +33,22 @@ public class RetrieveFiltersQuery {
                 .map(filterBuilder -> filterBuilder.build(accessToken))
                 .filter(Objects::nonNull)
                 .flatMap(Collection::stream)
+                .map(this::mapGroup)
                 .collect(Collectors.toList());
+    }
+
+    private Filter mapGroup(Filter filter) {
+        var nonNullGroups = ofNullable(datasetsConfig.filterGroups())
+                .orElseGet(List::of);
+
+        var group = nonNullGroups.stream()
+                .filter(it -> it.filters().contains(filter.getKey()))
+                .map(FilterGroup::key)
+                .findFirst()
+                .orElse(datasetsConfig.noGroupKey());
+
+        filter.setGroup(group);
+
+        return filter;
     }
 }

--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/filters/infrastructure/ckan/CkanFilterBuilder.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/filters/infrastructure/ckan/CkanFilterBuilder.java
@@ -5,6 +5,7 @@
 package io.github.genomicdatainfrastructure.discovery.filters.infrastructure.ckan;
 
 import io.github.genomicdatainfrastructure.discovery.filters.application.ports.FilterBuilder;
+import io.github.genomicdatainfrastructure.discovery.filters.infrastructure.quarkus.DatasetsConfig;
 import io.github.genomicdatainfrastructure.discovery.model.Filter;
 import io.github.genomicdatainfrastructure.discovery.model.FilterType;
 import io.github.genomicdatainfrastructure.discovery.model.ValueLabel;
@@ -13,7 +14,6 @@ import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.CkanFacet
 import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.PackageSearchRequest;
 import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.PackagesSearchResult;
 import jakarta.enterprise.context.ApplicationScoped;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 
 import java.util.List;
@@ -32,12 +32,12 @@ public class CkanFilterBuilder implements FilterBuilder {
 
     public CkanFilterBuilder(
             @RestClient CkanQueryApi ckanQueryApi,
-            @ConfigProperty(name = "datasets.filters") String datasetFiltersAsString
+            DatasetsConfig datasetsConfig
     ) {
         this.ckanQueryApi = ckanQueryApi;
         this.selectedFacets = SELECTED_FACETS_PATTERN.formatted(String.join(
                 "\",\"",
-                datasetFiltersAsString.split(",")
+                datasetsConfig.filters().split(",")
         ));
     }
 

--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/filters/infrastructure/quarkus/DatasetsConfig.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/filters/infrastructure/quarkus/DatasetsConfig.java
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: 2025 PNED G.I.E.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package io.github.genomicdatainfrastructure.discovery.filters.infrastructure.quarkus;
+
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
+import java.util.List;
+import java.util.Set;
+
+@ConfigMapping(prefix = "datasets")
+public interface DatasetsConfig {
+
+    String filters();
+
+    @WithDefault("NO_GROUP")
+    String noGroupKey();
+
+    List<FilterGroup> filterGroups();
+
+    interface FilterGroup {
+
+        String key();
+
+        Set<String> filters();
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -70,11 +70,15 @@ quarkus.otel.exporter.otlp.protocol=http/protobuf
 # Custom Application Properties
 sources.beacon=true
 datasets.filters=access_rights,theme,tags,publisher_name,res_format
+datasets.no-group-key=NO_GROUP
+datasets.filter-groups[0].key=DEFAULT
+datasets.filter-groups[0].filters=access_rights,theme,tags,publisher_name,res_format
+
 # Development Profile Specific Configuration
 %dev.quarkus.oidc.auth-server-url=https://id.portal.dev.gdi.lu/realms/gdi
 %dev.quarkus.oidc.client-id=gdi
 %dev.quarkus.oidc.credentials.secret=dummy-secret
-%dev.quarkus.rest-client.ckan_yaml.url=http://localhost:5500
+%dev.quarkus.rest-client.ckan_yaml.url=https://ckan.healthdata.nl
 %dev.quarkus.rest-client.keycloak_yaml.url=https://id.portal.dev.gdi.lu/realms/gdi
 %dev.quarkus.rest-client.individuals_yaml.url=https://beacon-network-backend-demo.ega-archive.org/beacon-network
 %dev.quarkus.rest-client.gvariants_yaml.url=https://af-gdi-bn-api-demo.ega-archive.org/beacon-network


### PR DESCRIPTION
## Summary by Sourcery

Add support for grouping filters by key via a new configuration mapping and propagate group assignments through the filter retrieval flow.

New Features:
- Group filters by key based on configurable filter groups defined in DatasetsConfig
- Introduce DatasetsConfig ConfigMapping interface to expose dataset filter settings, default group key, and filter groups

Enhancements:
- Modify RetrieveFiltersQuery to assign a group to each filter using DatasetsConfig.filterGroups or a default noGroupKey
- Update CkanFilterBuilder to source selected facets from DatasetsConfig instead of a raw config property

Documentation:
- Add datasets.no-group-key and datasets.filter-groups entries to application.properties

Tests:
- Mock DatasetsConfig in RetrieveFiltersQueryTest and adjust assertions to verify filter.group values
- Add a shouldGroupFilters test to validate grouping logic based on configured filter groups