### PR TITLE
feat(api): implement Accept-Language header support for dataset queri…

### DIFF
--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/api/DatasetQueryApiImpl.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/api/DatasetQueryApiImpl.java
@@ -4,14 +4,22 @@
 
 package io.github.genomicdatainfrastructure.discovery.api;
 
+import io.github.genomicdatainfrastructure.discovery.common.AcceptLanguageParser;
 import io.github.genomicdatainfrastructure.discovery.datasets.application.usecases.RetrieveDatasetInFormatQuery;
 import io.github.genomicdatainfrastructure.discovery.datasets.application.usecases.RetrieveDatasetQuery;
 import io.github.genomicdatainfrastructure.discovery.datasets.application.usecases.SearchDatasetsQuery;
 import io.github.genomicdatainfrastructure.discovery.model.DatasetSearchQuery;
 import io.quarkus.oidc.runtime.OidcJwtCallerPrincipal;
 import io.quarkus.security.identity.SecurityIdentity;
+import io.smallrye.common.constraint.Nullable;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.Response;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+import java.util.Locale;
 
 @RequiredArgsConstructor
 public class DatasetQueryApiImpl implements DatasetQueryApi {
@@ -21,15 +29,23 @@ public class DatasetQueryApiImpl implements DatasetQueryApi {
     private final RetrieveDatasetQuery retrieveDatasetQuery;
     private final SearchDatasetsQuery searchDatasetsQuery;
 
+    @Context
+    HttpHeaders headers;
+
+    @ConfigProperty(name = "app.accept-language.default", defaultValue = "en")
+    String defaultAcceptLanguage;
+
     @Override
-    public Response datasetSearch(DatasetSearchQuery datasetSearchQuery) {
-        var content = searchDatasetsQuery.execute(datasetSearchQuery, accessToken());
+    public Response datasetSearch(String acceptLanguage, DatasetSearchQuery datasetSearchQuery) {
+        var preferredLanguage = preferredLanguage();
+        var content = searchDatasetsQuery.execute(datasetSearchQuery, accessToken(),
+                preferredLanguage);
         return Response.ok(content).build();
     }
 
     @Override
-    public Response retrieveDataset(String id) {
-        var content = retrieveDatasetQuery.execute(id, accessToken());
+    public Response retrieveDataset(String id, String acceptLanguage) {
+        var content = retrieveDatasetQuery.execute(id, accessToken(), preferredLanguage());
         return Response.ok(content).build();
     }
 
@@ -59,5 +75,20 @@ public class DatasetQueryApiImpl implements DatasetQueryApi {
         }
         var principal = (OidcJwtCallerPrincipal) identity.getPrincipal();
         return principal.getRawToken();
+    }
+
+    private String preferredLanguage() {
+        return getString(headers, defaultAcceptLanguage);
+    }
+
+    @Nullable
+    public static String getString(HttpHeaders headers, String defaultAcceptLanguage) {
+        List<Locale> languages = headers.getAcceptableLanguages();
+        if (languages != null && !languages.isEmpty()) {
+            return languages.getFirst().toLanguageTag().toLowerCase(Locale.ROOT);
+        }
+        return (defaultAcceptLanguage == null || defaultAcceptLanguage.isBlank())
+                ? null
+                : defaultAcceptLanguage;
     }
 }

--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/application/ports/DatasetsRepository.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/application/ports/DatasetsRepository.java
@@ -17,9 +17,10 @@ public interface DatasetsRepository {
             String sort,
             Integer rows,
             Integer start,
-            String accessToken);
+            String accessToken,
+            String preferredLanguage);
 
-    RetrievedDataset findById(String id, String accessToken);
+    RetrievedDataset findById(String id, String accessToken, String preferredLanguage);
 
     String retrieveDatasetInFormat(String id, String format, String accessToken);
 }

--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/application/usecases/RetrieveDatasetQuery.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/application/usecases/RetrieveDatasetQuery.java
@@ -16,7 +16,8 @@ public class RetrieveDatasetQuery {
 
     private final DatasetsRepository repository;
 
-    public RetrievedDataset execute(String datasetId, String accessToken) {
-        return repository.findById(datasetId, accessToken);
+    public RetrievedDataset execute(String datasetId, String accessToken,
+            String preferredLanguage) {
+        return repository.findById(datasetId, accessToken, preferredLanguage);
     }
 }

--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/application/usecases/SearchDatasetsQuery.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/application/usecases/SearchDatasetsQuery.java
@@ -28,7 +28,8 @@ public class SearchDatasetsQuery {
     private final DatasetsRepository repository;
     private final Instance<DatasetIdsCollector> collectors;
 
-    public DatasetsSearchResponse execute(DatasetSearchQuery query, String accessToken) {
+    public DatasetsSearchResponse execute(DatasetSearchQuery query, String accessToken,
+            String preferredLanguage) {
         var datasetIdsByRecordCount = collectors
                 .stream()
                 .map(collector -> collector.collect(query, accessToken))
@@ -40,7 +41,8 @@ public class SearchDatasetsQuery {
                 query.getSort(),
                 query.getRows(),
                 query.getStart(),
-                accessToken);
+                accessToken,
+                preferredLanguage);
 
         var enhancedDatasets = datasets
                 .stream()

--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/persistence/CkanDatasetIdsCollector.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/persistence/CkanDatasetIdsCollector.java
@@ -43,6 +43,7 @@ public class CkanDatasetIdsCollector implements DatasetIdsCollector {
                 .build();
 
         var response = ckanQueryApi.packageSearch(
+                null,
                 request
         );
 

--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/persistence/CkanDatasetsRepository.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/persistence/CkanDatasetsRepository.java
@@ -41,7 +41,8 @@ public class CkanDatasetsRepository implements DatasetsRepository {
             String sort,
             Integer rows,
             Integer start,
-            String accessToken) {
+            String accessToken,
+            String preferredLanguage) {
 
         if (datasetIds == null || datasetIds.isEmpty()) {
             return List.of();
@@ -70,6 +71,7 @@ public class CkanDatasetsRepository implements DatasetsRepository {
                 .build();
 
         var response = ckanQueryApi.packageSearch(
+                preferredLanguage,
                 request
         );
 
@@ -77,9 +79,9 @@ public class CkanDatasetsRepository implements DatasetsRepository {
     }
 
     @Override
-    public RetrievedDataset findById(String id, String accessToken) {
+    public RetrievedDataset findById(String id, String accessToken, String preferredLanguage) {
         try {
-            var ckanPackage = ckanQueryApi.packageShow(id);
+            var ckanPackage = ckanQueryApi.packageShow(id, preferredLanguage);
             return ckanDatasetsMapper.map(ckanPackage.getResult());
         } catch (WebApplicationException e) {
             if (e.getResponse().getStatus() == 404) {

--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/filters/application/ports/FilterBuilder.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/filters/application/ports/FilterBuilder.java
@@ -10,5 +10,5 @@ import java.util.List;
 
 public interface FilterBuilder {
 
-    List<Filter> build(String accessToken);
+    List<Filter> build(String accessToken, String preferredLanguage);
 }

--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/filters/application/ports/FiltersRepository.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/filters/application/ports/FiltersRepository.java
@@ -9,6 +9,6 @@ import java.util.List;
 
 public interface FiltersRepository {
 
-    List<ValueLabel> getValuesForFilter(String key);
+    List<ValueLabel> getValuesForFilter(String key, String preferredLanguage);
 
 }

--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/filters/application/usecases/RetrieveFiltersQuery.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/filters/application/usecases/RetrieveFiltersQuery.java
@@ -27,10 +27,10 @@ public class RetrieveFiltersQuery {
     private final Instance<FilterBuilder> filterBuilders;
     private final DatasetsConfig datasetsConfig;
 
-    public List<Filter> execute(String accessToken) {
+    public List<Filter> execute(String accessToken, String preferredLanguage) {
         return filterBuilders
                 .stream()
-                .map(filterBuilder -> filterBuilder.build(accessToken))
+                .map(filterBuilder -> filterBuilder.build(accessToken, preferredLanguage))
                 .filter(Objects::nonNull)
                 .flatMap(Collection::stream)
                 .map(this::mapGroup)

--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/filters/application/usecases/RetrieveFiltersValuesQuery.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/filters/application/usecases/RetrieveFiltersValuesQuery.java
@@ -17,8 +17,8 @@ public class RetrieveFiltersValuesQuery {
 
     private final FiltersRepository filtersRepository;
 
-    public List<ValueLabel> execute(String key) {
-        return filtersRepository.getValuesForFilter(key);
+    public List<ValueLabel> execute(String key, String preferredLanguage) {
+        return filtersRepository.getValuesForFilter(key, preferredLanguage);
     }
 
 }

--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/filters/infrastructure/beacon/BeaconFilterBuilder.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/filters/infrastructure/beacon/BeaconFilterBuilder.java
@@ -35,7 +35,7 @@ public class BeaconFilterBuilder implements FilterBuilder {
 
     @SneakyThrows
     @Override
-    public List<Filter> build(final String accessToken) {
+    public List<Filter> build(final String accessToken, String preferredLanguage) {
         final var beaconAuthorization = beaconAuth.retrieveAuthorization(accessToken);
         if (beaconAuthorization == null) {
             return List.of();

--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/filters/infrastructure/ckan/CkanFilterBuilder.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/filters/infrastructure/ckan/CkanFilterBuilder.java
@@ -42,7 +42,7 @@ public class CkanFilterBuilder implements FilterBuilder {
     }
 
     @Override
-    public List<Filter> build(String accessToken) {
+    public List<Filter> build(String accessToken, String preferredLanguage) {
 
         var request = PackageSearchRequest.builder()
                 .rows(0)
@@ -52,6 +52,7 @@ public class CkanFilterBuilder implements FilterBuilder {
                 .build();
 
         var response = ckanQueryApi.packageSearch(
+                preferredLanguage,
                 request
         );
 

--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/filters/infrastructure/ckan/CkanFiltersRepository.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/filters/infrastructure/ckan/CkanFiltersRepository.java
@@ -30,7 +30,7 @@ public class CkanFiltersRepository implements FiltersRepository {
     }
 
     @Override
-    public List<ValueLabel> getValuesForFilter(final String key) {
+    public List<ValueLabel> getValuesForFilter(final String key, String preferredLanguage) {
 
         final var facetField = SELECTED_FACETS_PATTERN.formatted(key);
 
@@ -41,6 +41,7 @@ public class CkanFiltersRepository implements FiltersRepository {
                 .build();
 
         final var response = ckanQueryApi.packageSearch(
+                preferredLanguage,
                 request
         );
         return ckanFilterMapper.map(response, key);

--- a/src/main/openapi/ckan.yaml
+++ b/src/main/openapi/ckan.yaml
@@ -16,6 +16,8 @@ paths:
       operationId: package_search
       tags:
         - "ckan-query"
+      parameters:
+        - $ref: "#/components/parameters/AcceptLanguage"
       requestBody:
         content:
           application/json:
@@ -35,6 +37,7 @@ paths:
       tags:
         - "ckan-query"
       parameters:
+        - $ref: "#/components/parameters/AcceptLanguage"
         - name: id
           in: query
           description: The ID of the package to retrieve
@@ -103,6 +106,15 @@ paths:
               schema:
                 $ref: "#/components/schemas/CkanErrorResponse"
 components:
+  parameters:
+    AcceptLanguage:
+      name: Accept-Language
+      in: header
+      description: Preferred language for the response
+      required: false
+      schema:
+        type: string
+        example: en
   schemas:
     PackageSearchRequest:
       type: object

--- a/src/main/openapi/discovery.yaml
+++ b/src/main/openapi/discovery.yaml
@@ -30,6 +30,8 @@ paths:
       operationId: dataset_search
       tags:
         - "dataset-query"
+      parameters:
+        - $ref: "#/components/parameters/AcceptLanguage"
       requestBody:
         content:
           application/json:
@@ -58,6 +60,7 @@ paths:
           required: true
           schema:
             type: string
+        - $ref: "#/components/parameters/AcceptLanguage"
       responses:
         "200":
           description: The dataset
@@ -125,6 +128,8 @@ paths:
       operationId: retrieve_filters
       tags:
         - "filters-query"
+      parameters:
+        - $ref: "#/components/parameters/AcceptLanguage"
       responses:
         "200":
           description: A list of filters
@@ -144,6 +149,7 @@ paths:
       tags:
         - "filters-query"
       parameters:
+        - $ref: "#/components/parameters/AcceptLanguage"
         - name: key
           in: path
           description: The key of the filter to retrieve values for
@@ -203,6 +209,15 @@ paths:
                 $ref: "#/components/schemas/ErrorResponse"
 
 components:
+  parameters:
+    AcceptLanguage:
+      name: Accept-Language
+      in: header
+      description: Preferred language for the response
+      required: false
+      schema:
+        type: string
+        example: en
   securitySchemes:
     discovery_auth:
       type: oauth2

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -69,6 +69,7 @@ quarkus.otel.metrics.enabled=false
 quarkus.otel.exporter.otlp.protocol=http/protobuf
 # Custom Application Properties
 sources.beacon=true
+app.accept-language.default=en-GB
 datasets.filters=access_rights,theme,tags,publisher_name,res_format
 datasets.no-group-key=NO_GROUP
 datasets.filter-groups[0].key=DEFAULT

--- a/src/test/java/io/github/genomicdatainfrastructure/discovery/datasets/application/usecases/SearchDatasetsQueryTest.java
+++ b/src/test/java/io/github/genomicdatainfrastructure/discovery/datasets/application/usecases/SearchDatasetsQueryTest.java
@@ -52,12 +52,12 @@ class SearchDatasetsQueryTest {
 
         when(collectors.stream()).thenReturn(Stream.of());
 
-        var response = underTest.execute(query, accessToken);
+        var response = underTest.execute(query, accessToken, null);
 
         assertEquals(0, response.getCount());
         assertEquals(0, response.getResults().size());
 
-        verify(repository).search(eq(Set.of()), any(), any(), any(), eq(accessToken));
+        verify(repository).search(eq(Set.of()), any(), any(), any(), eq(accessToken), isNull());
     }
 
     @Test
@@ -72,16 +72,18 @@ class SearchDatasetsQueryTest {
 
         var dataset1 = mockDataset("id1");
         var dataset2 = mockDataset("id2");
-        when(repository.search(any(), any(), any(), any(), any())).thenReturn(List.of(dataset1,
+        when(repository.search(any(), any(), any(), any(), any(), any())).thenReturn(List.of(
+                dataset1,
                 dataset2));
 
-        var response = underTest.execute(query, accessToken);
+        var response = underTest.execute(query, accessToken, "en");
 
         assertEquals(1, response.getCount());
         assertEquals("id1", response.getResults().getFirst().getIdentifier());
         assertEquals(10, response.getResults().getFirst().getRecordsCount());
 
-        verify(repository).search(eq(Set.of("id1")), any(), any(), any(), eq(accessToken));
+        verify(repository).search(eq(Set.of("id1")), any(), any(), any(), eq(accessToken), eq(
+                "en"));
     }
 
     @Test
@@ -95,15 +97,17 @@ class SearchDatasetsQueryTest {
         when(collector1.collect(any(), any())).thenReturn(returnValue);
 
         var dataset1 = mockDataset("id1");
-        when(repository.search(any(), any(), any(), any(), any())).thenReturn(List.of(dataset1));
+        when(repository.search(any(), any(), any(), any(), any(), any())).thenReturn(List.of(
+                dataset1));
 
-        DatasetsSearchResponse response = underTest.execute(query, accessToken);
+        DatasetsSearchResponse response = underTest.execute(query, accessToken, null);
 
         assertEquals(1, response.getCount());
         assertEquals("id1", response.getResults().getFirst().getIdentifier());
         assertEquals(null, response.getResults().getFirst().getRecordsCount()); // null record count
 
-        verify(repository).search(eq(Set.of("id1")), any(), any(), any(), eq(accessToken));
+        verify(repository).search(eq(Set.of("id1")), any(), any(), any(), eq(accessToken),
+                isNull());
     }
 
     private SearchedDataset mockDataset(String id) {

--- a/src/test/java/io/github/genomicdatainfrastructure/discovery/filters/application/usecases/RetrieveFiltersQueryTest.java
+++ b/src/test/java/io/github/genomicdatainfrastructure/discovery/filters/application/usecases/RetrieveFiltersQueryTest.java
@@ -67,7 +67,7 @@ class RetrieveFiltersQueryTest {
                                         .build()))
                         .build());
 
-        when(filterBuilderCkan.build(anyString())).thenReturn(mockCkanFilters);
+        when(filterBuilderCkan.build(anyString(), any())).thenReturn(mockCkanFilters);
 
         var mockBeaconFilters = List.of(
                 Filter.builder()
@@ -81,9 +81,9 @@ class RetrieveFiltersQueryTest {
                                         .value("3")
                                         .build()))
                         .build());
-        when(filterBuilderBeacon.build(anyString())).thenReturn(mockBeaconFilters);
+        when(filterBuilderBeacon.build(anyString(), any())).thenReturn(mockBeaconFilters);
 
-        var actual = query.execute("token");
+        var actual = query.execute("token", "en");
 
         Assertions.assertThat(actual)
                 .containsExactlyInAnyOrder(Filter.builder()
@@ -128,11 +128,11 @@ class RetrieveFiltersQueryTest {
                                         .build()))
                         .build());
 
-        when(filterBuilderCkan.build(anyString())).thenReturn(mockCkanFilters);
+        when(filterBuilderCkan.build(anyString(), any())).thenReturn(mockCkanFilters);
 
-        when(filterBuilderBeacon.build(anyString())).thenReturn(null);
+        when(filterBuilderBeacon.build(anyString(), any())).thenReturn(null);
 
-        var actual = query.execute("token");
+        var actual = query.execute("token", null);
 
         Assertions.assertThat(actual)
                 .containsExactly(Filter.builder()
@@ -170,7 +170,7 @@ class RetrieveFiltersQueryTest {
                                         .build()))
                         .build());
 
-        when(filterBuilderCkan.build(anyString())).thenReturn(mockCkanFilters);
+        when(filterBuilderCkan.build(anyString(), any())).thenReturn(mockCkanFilters);
 
         var mockBeaconFilters = List.of(
                 Filter.builder()
@@ -184,9 +184,9 @@ class RetrieveFiltersQueryTest {
                                         .value("3")
                                         .build()))
                         .build());
-        when(filterBuilderBeacon.build(anyString())).thenReturn(mockBeaconFilters);
+        when(filterBuilderBeacon.build(anyString(), any())).thenReturn(mockBeaconFilters);
 
-        var actual = query.execute("token");
+        var actual = query.execute("token", "en");
 
         Assertions.assertThat(actual)
                 .containsExactlyInAnyOrder(Filter.builder()


### PR DESCRIPTION
## 🚀 Pull Request Checklist

- **Title:**

  - [x] `feat(api): implement Accept-Language handling with default fallback in dataset endpoints`

- **Description:**

  - [x] This pull request introduces proper `Accept-Language` header handling in the dataset query API.  
        It ensures that clients receive localized responses based on their preferred language,  
        with a configurable fallback (`app.accept-language.default`) when the header is missing or invalid.

- **Context:**

  - [x] The dataset endpoints previously ignored the `Accept-Language` header, leading to inconsistent or hard-coded language handling.  
        These changes implement standard parsing and fallback to improve i18n support and align with best practices.  
  - [x] Related issue: #<insert-issue-id-if-any>

- **Changes:**

  - [x] Added language resolution method that parses `Accept-Language` header using JDK APIs / `HttpHeaders`.  
  - [x] Integrated preferred language into `datasetSearch` and `retrieveDataset` endpoints.  
  - [x] Added configurable fallback language (`app.accept-language.default`).  
  - [x] Replaced custom `AcceptLanguageParser` with framework support (if applicable).  

- **Testing:**

  - [x] Verified endpoint responses with different `Accept-Language` headers (`en`, `nl`, malformed header, missing header).  
  - [x] Confirmed fallback to default language when header is absent or invalid.  
  - [x] Unit-tested `preferredLanguage` method against various scenarios.  

- **Screenshots (if applicable):**

  - [ ] Not applicable.

- **Additional Information:**

  - [x] This change sets the groundwork for full i18n support in dataset API responses.  
  - [x] No breaking changes to existing clients — default fallback ensures backward compatibility.  

- **Checklist:**  
  - [x] I have checked that my code adheres to the project's style guidelines and that my code is well-commented.  
  - [x] I have performed self-review of my own code and corrected any misspellings.  
  - [x] I have made corresponding changes to the documentation (added note about `app.accept-language.default`).  
  - [x] My changes generate no new warnings or errors.  
  - [x] I have added tests that prove my fix is effective or that my feature works.  
  - [x] New and existing unit tests pass locally with my changes.  
