### PR TITLE
Revert "fix(tags) reverts tags"

### DIFF
--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/mapper/CkanDatasetsMapper.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/mapper/CkanDatasetsMapper.java
@@ -82,11 +82,6 @@ public interface CkanDatasetsMapper {
     @Mapping(target = "count", source = "count")
     ValueLabel map(CkanValueLabel ckanValueLabel);
 
-    @Mapping(target = "label", source = "displayName")
-    @Mapping(target = "value", source = "name")
-    @Mapping(target = "count", ignore = true)
-    ValueLabel map(CkanTag ckanTag);
-
     @Mapping(target = "accessUrl", source = "accessUrl")
     @Mapping(target = "downloadUrl", source = "downloadUrl")
     @Mapping(target = "description", source = "description")

--- a/src/main/openapi/ckan.yaml
+++ b/src/main/openapi/ckan.yaml
@@ -199,7 +199,7 @@ components:
         tags:
           type: array
           items:
-            $ref: "#/components/schemas/CkanTag"
+            type: string
         contact:
           type: array
           items:
@@ -292,7 +292,7 @@ components:
         temporal_resolution:
           type: string
         population_coverage:
-          type: object
+          type: string
         retention_period:
           type: array
           items:
@@ -654,22 +654,6 @@ components:
           type: boolean
         result:
           $ref: "#/components/schemas/CkanPackage"
-    CkanTag:
-      type: object
-      properties:
-        id:
-          type: string
-        state:
-          type: string
-        display_name:
-          type: string
-        name:
-          type: string
-      required:
-        - id
-        - display_name
-        - name
-        - state
     CkanErrorResponse:
       type: object
       properties:

--- a/src/main/openapi/discovery.yaml
+++ b/src/main/openapi/discovery.yaml
@@ -349,7 +349,7 @@ components:
         keywords:
           type: array
           items:
-            $ref: "#/components/schemas/ValueLabel"
+            type: string
           title: Keywords
         catalogue:
           type: string
@@ -461,7 +461,7 @@ components:
         keywords:
           type: array
           items:
-            $ref: "#/components/schemas/ValueLabel"
+            type: string
         provenance:
           type: string
           title: Provenance
@@ -505,7 +505,7 @@ components:
         temporalResolution:
           type: string
         populationCoverage:
-          type: object
+          type: string
         retentionPeriod:
           type: array
           items:

--- a/src/test/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/mapper/CkanDatasetsMapperTest.java
+++ b/src/test/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/mapper/CkanDatasetsMapperTest.java
@@ -42,7 +42,6 @@ class CkanDatasetsMapperTest {
                     .themes(List.of())
                     .contacts(List.of())
                     .creators(List.of())
-                    .keywords(List.of())
                     .publishers(List.of())
                     .datasetRelationships(List.of())
                     .dataDictionary(List.of())
@@ -125,7 +124,7 @@ class CkanDatasetsMapperTest {
                     .accessRights(getValueLabel("accessRights", "public", 10))
                     .conformsTo(getValueLabels("conformsTo", "conforms", 5))
                     .provenance("provenance")
-                    .keywords(List.of(getValueLabel("key-tag", "key")))
+                    .keywords(List.of("key-tag"))
                     .spatial(getValueLabel("spatial", "uri"))
                     .distributions(List.of(
                             RetrievedDistribution.builder()
@@ -468,10 +467,7 @@ class CkanDatasetsMapperTest {
                                     .type("type2")
                                     .build()))
                     .themes(getValueLabels("theme", "theme-name", 3))
-                    .keywords(List.of(ValueLabel.builder()
-                            .value("key")
-                            .label("key-tag")
-                            .build()))
+                    .keywords(List.of("key-tag"))
                     .modifiedAt(OffsetDateTime.parse("2024-07-02T22:00Z"))
                     .createdAt(OffsetDateTime.parse("2024-07-01T22:00Z"))
                     .distributionsCount(1)
@@ -527,12 +523,8 @@ class CkanDatasetsMapperTest {
                 .build();
     }
 
-    private static @NotNull List<CkanTag> getCkanTags() {
-        return List.of(CkanTag.builder()
-                .displayName("key-tag")
-                .id("tag-id")
-                .name("key")
-                .build());
+    private static @NotNull List<String> getCkanTags() {
+        return List.of("key-tag");
     }
 
     private static @NotNull List<CkanValueLabel> getCkanValueLabels(String label, String value) {


### PR DESCRIPTION
This reverts commit efbc270efde9a1a1716d2c4519c011948a758d9e.

<!-- SPDX-FileCopyrightText: 2024 PNED G.I.E. -->

<!-- SPDX-License-Identifier: Apache-2.0 -->

## 🚀 Pull Request Checklist

- **Title:**

  - `[ ]` A brief, descriptive title for the changes.

- **Description:**

  - `[ ]` Provide a clear and concise description of your pull request, including the purpose of the changes and the approach you've taken.

- **Context:**

  - `[ ]` Why are these changes necessary? What problem do they solve? Link any related issues.

- **Changes:**

  - `[ ]` List the major changes you've made, ideally organized by commit or feature.

- **Testing:**

  - `[ ]` Describe how the changes have been tested. Include any relevant details about the testing environment and the test cases.

- **Screenshots (if applicable):**

  - `[ ]` If your changes are visual, include screenshots to help explain your changes.

- **Additional Information:**

  - `[ ]` Add any other information that might be useful for reviewers, such as considerations, discussions, or dependencies.

- **Checklist:**
  - `[ ]` I have checked that my code adheres to the project's style guidelines and that my code is well-commented.
  - `[ ]` I have performed self-review of my own code and corrected any misspellings.
  - `[ ]` I have made corresponding changes to the documentation (if applicable).
  - `[ ]` My changes generate no new warnings or errors.
  - `[ ]` I have added tests that prove my fix is effective or that my feature works.
  - `[ ]` New and existing unit tests pass locally with my changes.

## Summary by Sourcery

Revert the previous object-based tag implementation and restore primitive string arrays for tags and keywords throughout the OpenAPI specs, mapper, and tests

Enhancements:
- Update CKAN and discovery OpenAPI schemas to use array of strings for tags, keywords, and replace object-type fields with primitive string types
- Remove the CkanTag schema and its corresponding mapper method from the codebase

Tests:
- Adjust unit tests to expect and handle lists of strings for tags and keywords instead of object models