### PR TITLE
feat: Add conformsTo field to dataset search and retrieval endpoints

### DIFF
--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/mapper/CkanDatasetsMapper.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/mapper/CkanDatasetsMapper.java
@@ -147,6 +147,7 @@ public interface CkanDatasetsMapper {
     @Mapping(target = "modifiedAt", source = "modified")
     @Mapping(target = "createdAt", source = "issued")
     @Mapping(target = "accessRights", source = "accessRights")
+    @Mapping(target = "conformsTo", source = "conformsTo")
     @Mapping(target = "numberOfUniqueIndividuals", source = "numberOfUniqueIndividuals")
     @Mapping(target = "temporalCoverage.start", source = "temporalStart")
     @Mapping(target = "temporalCoverage.end", source = "temporalEnd")

--- a/src/main/openapi/discovery.yaml
+++ b/src/main/openapi/discovery.yaml
@@ -374,6 +374,11 @@ components:
           title: Metadata for dataset created at
         accessRights:
           $ref: "#/components/schemas/ValueLabel"
+        conformsTo:
+          type: array
+          items:
+            $ref: "#/components/schemas/ValueLabel"
+          title: Conforms To
         numberOfUniqueIndividuals:
           type: integer
           minimum: 0
@@ -923,6 +928,7 @@ components:
           type: string
           description: Centroid
     Filter:
+      type: object
       properties:
         source:
           type: string
@@ -969,6 +975,7 @@ components:
           type: string
           title: maximum value supported by the filter
     FilterEntry:
+      type: object
       properties:
         key:
           type: string
@@ -980,6 +987,7 @@ components:
         - key
         - label
     ErrorResponse:
+      type: object
       properties:
         title:
           type: string

--- a/src/test/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/mapper/CkanDatasetsMapperTest.java
+++ b/src/test/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/mapper/CkanDatasetsMapperTest.java
@@ -505,6 +505,9 @@ class CkanDatasetsMapperTest {
                     .distributionsCount(1)
                     .numberOfUniqueIndividuals(123456789)
                     .accessRights(getValueLabel("accessRights", "public", 10))
+                    .conformsTo(
+                            getValueLabels("DCAT-AP 3.0",
+                                    "https://data.europa.eu/dcat-ap/3.0"))
                     .temporalCoverage(TimeWindow.builder()
                             .start(parse("2024-07-12T22:00Z"))
                             .end(parse("2024-07-13T22:00Z"))


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: 2024 PNED G.I.E. -->

<!-- SPDX-License-Identifier: Apache-2.0 -->

## 🚀 Pull Request Checklist

- **Title:**

  - `[ ]` A brief, descriptive title for the changes.

- **Description:**

  - `[ ]` Provide a clear and concise description of your pull request, including the purpose of the changes and the approach you've taken.

- **Context:**

  - `[ ]` Why are these changes necessary? What problem do they solve? Link any related issues.

- **Changes:**

  - `[ ]` List the major changes you've made, ideally organized by commit or feature.

- **Testing:**

  - `[ ]` Describe how the changes have been tested. Include any relevant details about the testing environment and the test cases.

- **Screenshots (if applicable):**

  - `[ ]` If your changes are visual, include screenshots to help explain your changes.

- **Additional Information:**

  - `[ ]` Add any other information that might be useful for reviewers, such as considerations, discussions, or dependencies.

- **Checklist:**
  - `[ ]` I have checked that my code adheres to the project's style guidelines and that my code is well-commented.
  - `[ ]` I have performed self-review of my own code and corrected any misspellings.
  - `[ ]` I have made corresponding changes to the documentation (if applicable).
  - `[ ]` My changes generate no new warnings or errors.
  - `[ ]` I have added tests that prove my fix is effective or that my feature works.
  - `[ ]` New and existing unit tests pass locally with my changes.

## Summary by Sourcery

Add support for the dataset `conformsTo` metadata field in discovery APIs and their CKAN dataset mapping.

New Features:
- Expose a `conformsTo` array field in the dataset schema for search and retrieval endpoints.

Enhancements:
- Extend the CKAN dataset mapper to populate the new `conformsTo` field from CKAN metadata.
- Tighten OpenAPI schema definitions by explicitly declaring object types for filter-related and error response components.

Tests:
- Update CKAN dataset mapper tests to cover mapping of the new `conformsTo` field.