### PR TITLE
fix: update variant example

### DIFF
--- a/_http/beacon.http
+++ b/_http/beacon.http
@@ -108,10 +108,10 @@ Authorization: Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJCNXUyN0
     "query": {
         "filters": [],
         "requestParameters": {
-          "alternateBases": "C" ,
-          "referenceBases": "T" ,
-          "start": [45864731],
-          "referenceName": "3",
+          "alternateBases": "T" ,
+          "referenceBases": "G" ,
+          "start": [9411448],
+          "referenceName": "21",
           "assemblyId": "GRCh37"
         },
         "includeResultsetResponses": "HIT",
@@ -125,4 +125,4 @@ Authorization: Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJCNXUyN0
 }
 
 ### G_VARAINRTS
-GET https://af-gdi-bn-api-demo.ega-archive.org/beacon-network/v2.0.0/g_variants?start=45864731&alternateBases=C&referenceBases=T&referenceName=3&limit=1&assemblyId=GRCh37
+GET https://af-gdi-bn-api-demo.ega-archive.org/beacon-network/v2.0.0/g_variants?start=9411448&alternateBases=T&referenceBases=G&referenceName=21&limit=1&assemblyId=GRCh37

--- a/src/main/openapi/discovery.yaml
+++ b/src/main/openapi/discovery.yaml
@@ -1034,14 +1034,14 @@ components:
           type: string
           title: Reference Name
           description: Optional chromosome name/identifier.
-          example: "3"
+          example: "21"
         start:
           type: array
           title: Start Position
           description: Optional array of start positions on the reference sequence
           items:
             type: integer
-          example: [45864731]
+          example: [9411448]
         end:
           type: array
           title: End Position
@@ -1053,15 +1053,17 @@ components:
           type: string
           title: Reference Bases
           description: Optional reference allele sequence.
+          example: "G"
         alternateBases:
           type: string
           title: Alternate Bases
           description: Optional alternate allele sequence.
-          example: "C"
+          example: "T"
         assemblyId:
           type: string
           title: Assembly ID
-          description: Optional reference genome assembly identifier (e.g., "GRCh37", "GRCh38"). 
+          description: Optional reference genome assembly identifier (e.g., "GRCh37", "GRCh38").
+          example: "GRCh37" 
         sex:
           type: string
           title: Sex

--- a/src/main/openapi/discovery.yaml
+++ b/src/main/openapi/discovery.yaml
@@ -1027,20 +1027,18 @@ components:
       properties:
         params:
           $ref: "#/components/schemas/GVariantSearchQueryParams"
-      required:
-        - params
     GVariantSearchQueryParams:
       type: object
       properties:
         referenceName:
           type: string
           title: Reference Name
-          description: Chromosome name/identifier
+          description: Optional chromosome name/identifier.
           example: "3"
         start:
           type: array
           title: Start Position
-          description: Array of start positions on the reference sequence
+          description: Optional array of start positions on the reference sequence
           items:
             type: integer
           example: [45864731]
@@ -1054,34 +1052,26 @@ components:
         referenceBases:
           type: string
           title: Reference Bases
-          description: The reference allele sequence
-          example: "T"
+          description: Optional reference allele sequence.
         alternateBases:
           type: string
           title: Alternate Bases
-          description: The alternate allele sequence
+          description: Optional alternate allele sequence.
           example: "C"
         assemblyId:
           type: string
           title: Assembly ID
-          description: Reference genome assembly identifier
-          example: "GRCh37"
+          description: Optional reference genome assembly identifier (e.g., "GRCh37", "GRCh38"). 
         sex:
           type: string
           title: Sex
-          description: Optional sex filter (M or F)
+          description: Optional sex filter (M or F).
           example: "F"
         countryOfBirth:
           type: string
           title: Country of Birth
-          description: Optional country of birth (2-letter ISO code)
+          description: Optional country of birth (2-letter ISO code). 
           example: "FR"
-      required:
-        - referenceName
-        - start
-        - referenceBases
-        - alternateBases
-        - assemblyId
     GVariantsSearchResponse:
       type: object
       properties:

--- a/src/test/java/io/github/genomicdatainfrastructure/discovery/api/GVariantsApiIT.java
+++ b/src/test/java/io/github/genomicdatainfrastructure/discovery/api/GVariantsApiIT.java
@@ -126,10 +126,10 @@ class GVariantsApiIT extends BaseTest {
             String countryOfBirth, String sex) {
         GVariantSearchQuery query = new GVariantSearchQuery();
         GVariantSearchQueryParams params = new GVariantSearchQueryParams();
-        params.setReferenceName("3");
-        params.setStart(java.util.List.of(45864731));
-        params.setReferenceBases("T");
-        params.setAlternateBases("C");
+        params.setReferenceName("21");
+        params.setStart(java.util.List.of(9411448));
+        params.setReferenceBases("G");
+        params.setAlternateBases("T");
         params.setAssemblyId(assemblyId);
         params.setCountryOfBirth(countryOfBirth);
         params.setSex(sex);

--- a/src/test/java/io/github/genomicdatainfrastructure/discovery/api/GVariantsApiIT.java
+++ b/src/test/java/io/github/genomicdatainfrastructure/discovery/api/GVariantsApiIT.java
@@ -97,19 +97,40 @@ class GVariantsApiIT extends BaseTest {
                 .body("[0].sex", equalTo("F"));
     }
 
+    @Test
+    void givenNoAssemblyId_whenSearchGenomicVariants_thenReturnsResultsAcrossAllAssemblies() {
+        GVariantSearchQuery query = buildQueryWithAssemblyId(null);
+        given()
+                .contentType(JSON)
+                .body(query)
+                .when()
+                .post("/api/v1/g_variants")
+                .then()
+                .statusCode(200);
+    }
+
     private static @NotNull GVariantSearchQuery buildQuery() {
         return buildQueryWithFilters(null, null);
     }
 
     private static @NotNull GVariantSearchQuery buildQueryWithFilters(String countryOfBirth,
             String sex) {
+        return buildQueryWithAssemblyId("GRCh37", countryOfBirth, sex);
+    }
+
+    private static @NotNull GVariantSearchQuery buildQueryWithAssemblyId(String assemblyId) {
+        return buildQueryWithAssemblyId(assemblyId, null, null);
+    }
+
+    private static @NotNull GVariantSearchQuery buildQueryWithAssemblyId(String assemblyId,
+            String countryOfBirth, String sex) {
         GVariantSearchQuery query = new GVariantSearchQuery();
         GVariantSearchQueryParams params = new GVariantSearchQueryParams();
         params.setReferenceName("3");
         params.setStart(java.util.List.of(45864731));
         params.setReferenceBases("T");
         params.setAlternateBases("C");
-        params.setAssemblyId("GRCh37");
+        params.setAssemblyId(assemblyId);
         params.setCountryOfBirth(countryOfBirth);
         params.setSex(sex);
         query.setParams(params);

--- a/src/test/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/beacon/persistence/BeaconGVariantsRequestMapperTest.java
+++ b/src/test/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/beacon/persistence/BeaconGVariantsRequestMapperTest.java
@@ -24,10 +24,10 @@ class BeaconGVariantsRequestMapperTest {
     void map_GVariantSearchQuery_WithNullAssemblyId_DoesNotIncludeAssemblyId() {
         GVariantSearchQuery query = new GVariantSearchQuery();
         GVariantSearchQueryParams params = new GVariantSearchQueryParams();
-        params.setReferenceName("3");
-        params.setStart(List.of(45864731));
-        params.setReferenceBases("T");
-        params.setAlternateBases("C");
+        params.setReferenceName("21");
+        params.setStart(List.of(9411448));
+        params.setReferenceBases("G");
+        params.setAlternateBases("T");
         params.setAssemblyId(null);
         query.setParams(params);
 
@@ -39,7 +39,7 @@ class BeaconGVariantsRequestMapperTest {
         assertNotNull(requestParams);
         assertFalse(requestParams.containsKey("assemblyId"),
                 "assemblyId should not be included when null");
-        assertEquals("3", requestParams.get("referenceName"));
+        assertEquals("21", requestParams.get("referenceName"));
     }
 
     @Test
@@ -47,10 +47,10 @@ class BeaconGVariantsRequestMapperTest {
     void map_GVariantSearchQuery_WithSpecificAssemblyId_IncludesAssemblyId() {
         GVariantSearchQuery query = new GVariantSearchQuery();
         GVariantSearchQueryParams params = new GVariantSearchQueryParams();
-        params.setReferenceName("3");
-        params.setStart(List.of(45864731));
-        params.setReferenceBases("T");
-        params.setAlternateBases("C");
+        params.setReferenceName("21");
+        params.setStart(List.of(9411448));
+        params.setReferenceBases("G");
+        params.setAlternateBases("T");
         params.setAssemblyId("GRCh37");
         query.setParams(params);
 

--- a/src/test/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/beacon/persistence/BeaconGVariantsRequestMapperTest.java
+++ b/src/test/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/beacon/persistence/BeaconGVariantsRequestMapperTest.java
@@ -4,6 +4,8 @@
 
 package io.github.genomicdatainfrastructure.discovery.datasets.infrastructure.beacon.persistence;
 
+import io.github.genomicdatainfrastructure.discovery.model.GVariantSearchQuery;
+import io.github.genomicdatainfrastructure.discovery.model.GVariantSearchQueryParams;
 import io.github.genomicdatainfrastructure.discovery.model.GVariantsSearchResponse;
 import io.github.genomicdatainfrastructure.discovery.remote.beacon.gvariants.model.*;
 import org.junit.jupiter.api.DisplayName;
@@ -16,6 +18,52 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.*;
 
 class BeaconGVariantsRequestMapperTest {
+
+    @Test
+    @DisplayName("map(GVariantSearchQuery) should not include assemblyId when null")
+    void map_GVariantSearchQuery_WithNullAssemblyId_DoesNotIncludeAssemblyId() {
+        GVariantSearchQuery query = new GVariantSearchQuery();
+        GVariantSearchQueryParams params = new GVariantSearchQueryParams();
+        params.setReferenceName("3");
+        params.setStart(List.of(45864731));
+        params.setReferenceBases("T");
+        params.setAlternateBases("C");
+        params.setAssemblyId(null);
+        query.setParams(params);
+
+        var result = BeaconGVariantsRequestMapper.map(query);
+
+        assertNotNull(result);
+        assertNotNull(result.getQuery());
+        var requestParams = result.getQuery().getRequestParameters();
+        assertNotNull(requestParams);
+        assertFalse(requestParams.containsKey("assemblyId"),
+                "assemblyId should not be included when null");
+        assertEquals("3", requestParams.get("referenceName"));
+    }
+
+    @Test
+    @DisplayName("map(GVariantSearchQuery) should include assemblyId when set to specific value")
+    void map_GVariantSearchQuery_WithSpecificAssemblyId_IncludesAssemblyId() {
+        GVariantSearchQuery query = new GVariantSearchQuery();
+        GVariantSearchQueryParams params = new GVariantSearchQueryParams();
+        params.setReferenceName("3");
+        params.setStart(List.of(45864731));
+        params.setReferenceBases("T");
+        params.setAlternateBases("C");
+        params.setAssemblyId("GRCh37");
+        query.setParams(params);
+
+        var result = BeaconGVariantsRequestMapper.map(query);
+
+        assertNotNull(result);
+        assertNotNull(result.getQuery());
+        var requestParams = result.getQuery().getRequestParameters();
+        assertNotNull(requestParams);
+        assertTrue(requestParams.containsKey("assemblyId"),
+                "assemblyId should be included when set to a specific value");
+        assertEquals("GRCh37", requestParams.get("assemblyId"));
+    }
 
     // Note: BeaconRequest mapping test removed as it requires full query object setup
     // The response mapping test below covers the critical population parsing logic

--- a/src/test/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/beacon/persistence/GVariantsRepositoryTest.java
+++ b/src/test/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/beacon/persistence/GVariantsRepositoryTest.java
@@ -29,7 +29,7 @@ class GVariantsRepositoryTest {
 
     @Test
     void givenNonEmptyQueryParams_whenSearch_thenReturnsMappedResponse() {
-        var query = createQuery("3:45864731:T:C", "GRCh37", null, null);
+        var query = createQuery("21:9411448:G:T", "GRCh37", null, null);
         when(gVariantsApi.postGenomicVariationsRequest(any())).thenReturn(buildBeaconsResponse());
 
         var result = gVariantsRepository.search(query);
@@ -41,7 +41,7 @@ class GVariantsRepositoryTest {
 
     @Test
     void givenCombinedFilters_whenSearch_thenFiltersExactMatch() {
-        var query = createQuery("3:45864731:T:C", "GRCh37", "FR", "M");
+        var query = createQuery("21:9411448:G:T", "GRCh37", "FR", "M");
         when(gVariantsApi.postGenomicVariationsRequest(any())).thenReturn(
                 buildBeaconsResponseWithPopulation("FR_M"));
 

--- a/src/test/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/beacon/persistence/GVariantsRepositoryTest.java
+++ b/src/test/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/beacon/persistence/GVariantsRepositoryTest.java
@@ -40,38 +40,6 @@ class GVariantsRepositoryTest {
     }
 
     @Test
-    void givenEmptyFilters_whenSearch_thenReturnsAllVariants() {
-        var query = createQuery("3:45864731:T:C", "GRCh37", null, null);
-        when(gVariantsApi.postGenomicVariationsRequest(any())).thenReturn(buildBeaconsResponse());
-
-        var result = gVariantsRepository.search(query);
-
-        assertEquals(1, result.size());
-    }
-
-    @Test
-    void givenCountryFilter_whenSearch_thenFiltersCorrectly() {
-        var query = createQuery("3:45864731:T:C", "GRCh37", "FI", null);
-        when(gVariantsApi.postGenomicVariationsRequest(any())).thenReturn(
-                buildBeaconsResponseWithPopulation("FI"));
-
-        var result = gVariantsRepository.search(query);
-
-        assertEquals(1, result.size());
-    }
-
-    @Test
-    void givenInvalidPopulation_whenSearch_thenFiltersOut() {
-        var query = createQuery("3:45864731:T:C", "GRCh37", "FI", null);
-        when(gVariantsApi.postGenomicVariationsRequest(any())).thenReturn(
-                buildBeaconsResponseWithPopulation("INVALID"));
-
-        var result = gVariantsRepository.search(query);
-
-        assertTrue(result.isEmpty());
-    }
-
-    @Test
     void givenCombinedFilters_whenSearch_thenFiltersExactMatch() {
         var query = createQuery("3:45864731:T:C", "GRCh37", "FR", "M");
         when(gVariantsApi.postGenomicVariationsRequest(any())).thenReturn(


### PR DESCRIPTION
## Summary by Sourcery

Clarify handling of optional assemblyId and update variant examples in genomic variant search across tests and API specification.

Enhancements:
- Relax GVariantSearchQuery and GVariantSearchQueryParams schema to make key search parameters optional and document that assemblyId is optional and may span multiple reference assemblies.
- Update OpenAPI examples for genomic variant search to use a consistent 21:9411448 G>T example and clarify field descriptions as optional.

Documentation:
- Refresh discovery API OpenAPI documentation for genomic variant search parameters and examples to match current behavior.

Tests:
- Add unit and integration tests verifying that omitting assemblyId in genomic variant search omits it from the request and allows searching across all assemblies.
- Adjust repository and API integration tests to use the updated 21:9411448 G>T variant example and remove redundant repository filter tests.