### PR TITLE
fix: remove dataset license from API response

### DIFF
--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/mapper/CkanDatasetsMapper.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/mapper/CkanDatasetsMapper.java
@@ -83,7 +83,6 @@ public interface CkanDatasetsMapper {
     @Mapping(target = "healthTheme", source = "healthTheme")
     @Mapping(target = "versionNotes", source = "versionNotes")
     @Mapping(target = "version", source = "version")
-    @Mapping(target = "license", source = "licenseId")
     @Mapping(target = "ownerOrg", source = "ownerOrg")
     RetrievedDataset map(CkanPackage ckanPackage);
 

--- a/src/main/openapi/discovery.yaml
+++ b/src/main/openapi/discovery.yaml
@@ -426,10 +426,6 @@ components:
           type: string
           title: Version
           description: Version number or other version designation of the dataset.
-        license:
-          type: string
-          title: License
-          description: License identifier for the dataset.
         ownerOrg:
           type: string
           title: Owner Organization

--- a/src/test/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/mapper/CkanDatasetsMapperTest.java
+++ b/src/test/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/mapper/CkanDatasetsMapperTest.java
@@ -82,7 +82,6 @@ class CkanDatasetsMapperTest {
                     .identifier("identifier")
                     .title("title")
                     .version("1.0.0")
-                    .license("CC-BY-4.0")
                     .ownerOrg("test-organization")
                     .dcatType(getValueLabel("type", "type-uri"))
                     .description("notes")


### PR DESCRIPTION
## Summary
- remove dataset-level license from the CKAN to API mapper
- remove the dataset license field from the OpenAPI RetrievedDataset schema
- update mapper tests to reflect the contract change

## Testing
- mvn -Dtest=CkanDatasetsMapperTest test

## Summary by Sourcery

Remove dataset-level license from the public dataset discovery API contract and its CKAN mapper.

Bug Fixes:
- Align the dataset discovery API response with the intended contract by omitting the dataset-level license field.

Tests:
- Update CKAN dataset mapper tests to reflect the removal of the dataset-level license from the RetrievedDataset schema.