### PR TITLE
Filter discovery-service CKAN queries to datasets

### DIFF
--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/application/usecases/SearchDatasetsQuery.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/application/usecases/SearchDatasetsQuery.java
@@ -104,7 +104,7 @@ public class SearchDatasetsQuery {
 
         return DatasetsSearchResponse
                 .builder()
-                .count(searchResult.getCount())
+                .count(datasetIdsByRecordCount.size())
                 .results(enhancedDatasets)
                 .beaconError(beaconError)
                 .build();

--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/config/CkanConfiguration.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/config/CkanConfiguration.java
@@ -9,4 +9,12 @@ public class CkanConfiguration {
     public static final String CKAN_IDENTIFIER_FIELD = "identifier";
     public static final String CKAN_FILTER_SOURCE = "ckan";
     public static final int CKAN_PAGINATION_MAX_SIZE = 1000;
+    public static final String CKAN_DATASET_TYPE_FILTER = "type:(\"dataset\")";
+
+    public static String withDatasetTypeFilter(String fq) {
+        if (fq == null || fq.isBlank()) {
+            return CKAN_DATASET_TYPE_FILTER;
+        }
+        return "%s AND %s".formatted(fq, CKAN_DATASET_TYPE_FILTER);
+    }
 }

--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/persistence/CkanDatasetIdsCollector.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/persistence/CkanDatasetIdsCollector.java
@@ -18,6 +18,7 @@ import java.util.Map;
 import java.util.Objects;
 
 import static io.github.genomicdatainfrastructure.discovery.datasets.infrastructure.ckan.config.CkanConfiguration.CKAN_PAGINATION_MAX_SIZE;
+import static io.github.genomicdatainfrastructure.discovery.datasets.infrastructure.ckan.config.CkanConfiguration.withDatasetTypeFilter;
 
 @ApplicationScoped
 public class CkanDatasetIdsCollector implements DatasetIdsCollector {
@@ -33,7 +34,7 @@ public class CkanDatasetIdsCollector implements DatasetIdsCollector {
 
     @Override
     public Map<String, Integer> collect(DatasetSearchQuery query, String accessToken) {
-        var facetsQuery = CkanFacetsQueryBuilder.buildFacetQuery(query);
+        var facetsQuery = withDatasetTypeFilter(CkanFacetsQueryBuilder.buildFacetQuery(query));
 
         var datasetIdsByRecordCount = new HashMap<String, Integer>();
         var start = 0;

--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/persistence/CkanDatasetsRepository.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/persistence/CkanDatasetsRepository.java
@@ -20,6 +20,7 @@ import java.util.Set;
 
 import static io.github.genomicdatainfrastructure.discovery.datasets.infrastructure.ckan.config.CkanConfiguration.CKAN_FILTER_SOURCE;
 import static io.github.genomicdatainfrastructure.discovery.datasets.infrastructure.ckan.config.CkanConfiguration.CKAN_IDENTIFIER_FIELD;
+import static io.github.genomicdatainfrastructure.discovery.datasets.infrastructure.ckan.config.CkanConfiguration.withDatasetTypeFilter;
 import static java.util.Optional.ofNullable;
 
 @ApplicationScoped
@@ -39,9 +40,11 @@ public class CkanDatasetsRepository implements DatasetsRepository {
     @Override
     public DatasetsSearchResponse search(DatasetSearchQuery query, String accessToken,
             String preferredLanguage) {
+        var facetsQuery = withDatasetTypeFilter(CkanFacetsQueryBuilder.buildFacetQuery(query));
+
         var request = PackageSearchRequest.builder()
                 .q(query.getQuery())
-                .fq(CkanFacetsQueryBuilder.buildFacetQuery(query))
+                .fq(facetsQuery)
                 .sort(query.getSort())
                 .rows(query.getRows())
                 .start(query.getStart())
@@ -138,9 +141,9 @@ public class CkanDatasetsRepository implements DatasetsRepository {
                         .build())
                 .toList();
 
-        return CkanFacetsQueryBuilder.buildFacetQuery(DatasetSearchQuery
+        return withDatasetTypeFilter(CkanFacetsQueryBuilder.buildFacetQuery(DatasetSearchQuery
                 .builder()
                 .facets(facets)
-                .build());
+                .build()));
     }
 }

--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/filters/infrastructure/ckan/CkanFilterBuilder.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/filters/infrastructure/ckan/CkanFilterBuilder.java
@@ -30,6 +30,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import static io.github.genomicdatainfrastructure.discovery.datasets.infrastructure.ckan.config.CkanConfiguration.CKAN_FILTER_SOURCE;
+import static io.github.genomicdatainfrastructure.discovery.datasets.infrastructure.ckan.config.CkanConfiguration.withDatasetTypeFilter;
 import static java.util.Optional.ofNullable;
 
 @ApplicationScoped
@@ -61,6 +62,7 @@ public class CkanFilterBuilder implements FilterBuilder {
                 .rows(0)
                 .start(0)
                 .facetLimit(-1)
+                .fq(withDatasetTypeFilter(null))
                 .facetField(selectedFacets)
                 .build();
 

--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/filters/infrastructure/ckan/CkanFiltersRepository.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/filters/infrastructure/ckan/CkanFiltersRepository.java
@@ -14,6 +14,8 @@ import org.eclipse.microprofile.rest.client.inject.RestClient;
 
 import java.util.List;
 
+import static io.github.genomicdatainfrastructure.discovery.datasets.infrastructure.ckan.config.CkanConfiguration.withDatasetTypeFilter;
+
 @ApplicationScoped
 public class CkanFiltersRepository implements FiltersRepository {
 
@@ -38,6 +40,7 @@ public class CkanFiltersRepository implements FiltersRepository {
                 .facetField(facetField)
                 .rows(0)
                 .facetLimit(-1)
+                .fq(withDatasetTypeFilter(null))
                 .build();
 
         final var response = ckanQueryApi.packageSearch(

--- a/src/test/java/io/github/genomicdatainfrastructure/discovery/datasets/application/usecases/SearchDatasetsQueryTest.java
+++ b/src/test/java/io/github/genomicdatainfrastructure/discovery/datasets/application/usecases/SearchDatasetsQueryTest.java
@@ -97,6 +97,27 @@ class SearchDatasetsQueryTest {
     }
 
     @Test
+    void testExecute_withIncludeBeaconTrue_shouldCountIntersectedDatasets() {
+        var query = DatasetSearchQuery.builder()
+                .includeBeacon(true)
+                .build();
+
+        when(ckanCollector.collect(any(), any())).thenReturn(Map.of("id1", 10, "id2", 20, "id3",
+                30));
+        when(beaconCollector.collect(any(), any())).thenReturn(Map.of("id1", 64));
+        when(repository.search(any(), any(), any(), any(), any(), any())).thenReturn(searchResponse(
+                3,
+                List.of(mockDataset("id1"), mockDataset("id2"), mockDataset("id3"))));
+
+        var response = underTest.execute(query, "token", "en");
+
+        assertEquals(1, response.getCount());
+        assertEquals(1, response.getResults().size());
+        assertEquals("id1", response.getResults().get(0).getIdentifier());
+        assertEquals(10, response.getResults().get(0).getRecordsCount());
+    }
+
+    @Test
     void testExecute_whenBeaconReturnsError_capturesError() {
         var query = DatasetSearchQuery.builder()
                 .includeBeacon(true)

--- a/src/test/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/CkanDatasetIdsCollectorTest.java
+++ b/src/test/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/CkanDatasetIdsCollectorTest.java
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: 2026 PNED G.I.E.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package io.github.genomicdatainfrastructure.discovery.datasets.infrastructure.ckan;
+
+import static io.github.genomicdatainfrastructure.discovery.datasets.infrastructure.ckan.config.CkanConfiguration.CKAN_DATASET_TYPE_FILTER;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.github.genomicdatainfrastructure.discovery.datasets.infrastructure.ckan.persistence.CkanDatasetIdsCollector;
+import io.github.genomicdatainfrastructure.discovery.model.DatasetSearchQuery;
+import io.github.genomicdatainfrastructure.discovery.model.DatasetSearchQueryFacet;
+import io.github.genomicdatainfrastructure.discovery.model.FilterType;
+import io.github.genomicdatainfrastructure.discovery.remote.ckan.api.CkanQueryApi;
+import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.CkanPackage;
+import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.PackageSearchRequest;
+import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.PackagesSearchResponse;
+import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.PackagesSearchResult;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class CkanDatasetIdsCollectorTest {
+
+    @Test
+    void collectAddsDatasetTypeFilterToFacetQuery() {
+        var ckanQueryApi = mock(CkanQueryApi.class);
+        when(ckanQueryApi.packageSearch(isNull(), any(PackageSearchRequest.class))).thenReturn(
+                PackagesSearchResponse.builder()
+                        .result(PackagesSearchResult.builder()
+                                .count(1)
+                                .results(List.of(CkanPackage.builder().identifier("dataset-1")
+                                        .build()))
+                                .build())
+                        .build());
+
+        var collector = new CkanDatasetIdsCollector(ckanQueryApi);
+        var query = DatasetSearchQuery.builder()
+                .facets(List.of(
+                        DatasetSearchQueryFacet.builder()
+                                .source("ckan")
+                                .type(FilterType.DROPDOWN)
+                                .key("tags")
+                                .value("COVID")
+                                .build()))
+                .build();
+
+        var ids = collector.collect(query, null);
+
+        var requestCaptor = ArgumentCaptor.forClass(PackageSearchRequest.class);
+        verify(ckanQueryApi).packageSearch(isNull(), requestCaptor.capture());
+        assertThat(requestCaptor.getValue().getFq())
+                .isEqualTo("tags:(\"COVID\") AND " + CKAN_DATASET_TYPE_FILTER);
+        assertThat(ids).containsOnlyKeys("dataset-1");
+    }
+}

--- a/src/test/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/CkanDatasetsRepositoryTest.java
+++ b/src/test/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/CkanDatasetsRepositoryTest.java
@@ -1,0 +1,79 @@
+// SPDX-FileCopyrightText: 2026 PNED G.I.E.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package io.github.genomicdatainfrastructure.discovery.datasets.infrastructure.ckan;
+
+import static io.github.genomicdatainfrastructure.discovery.datasets.infrastructure.ckan.config.CkanConfiguration.CKAN_DATASET_TYPE_FILTER;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.github.genomicdatainfrastructure.discovery.datasets.infrastructure.ckan.mapper.CkanDatasetsMapper;
+import io.github.genomicdatainfrastructure.discovery.datasets.infrastructure.ckan.persistence.CkanDatasetsRepository;
+import io.github.genomicdatainfrastructure.discovery.model.DatasetSearchQuery;
+import io.github.genomicdatainfrastructure.discovery.model.DatasetSearchQueryFacet;
+import io.github.genomicdatainfrastructure.discovery.model.FilterType;
+import io.github.genomicdatainfrastructure.discovery.remote.ckan.api.CkanQueryApi;
+import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.PackageSearchRequest;
+import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.PackagesSearchResponse;
+import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.PackagesSearchResult;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class CkanDatasetsRepositoryTest {
+
+    @Test
+    void searchAddsDatasetTypeFilterToFacetQuery() {
+        var ckanQueryApi = mock(CkanQueryApi.class);
+        var mapper = mock(CkanDatasetsMapper.class);
+        when(ckanQueryApi.packageSearch(eq("en"), any(PackageSearchRequest.class))).thenReturn(
+                PackagesSearchResponse.builder()
+                        .result(PackagesSearchResult.builder().count(0).results(List.of()).build())
+                        .build());
+        when(mapper.map(any(PackagesSearchResult.class))).thenReturn(List.of());
+
+        var repository = new CkanDatasetsRepository(ckanQueryApi, mapper);
+        var query = DatasetSearchQuery.builder()
+                .facets(List.of(
+                        DatasetSearchQueryFacet.builder()
+                                .source("ckan")
+                                .type(FilterType.DROPDOWN)
+                                .key("tags")
+                                .value("COVID")
+                                .build()))
+                .build();
+
+        repository.search(query, null, "en");
+
+        var requestCaptor = ArgumentCaptor.forClass(PackageSearchRequest.class);
+        verify(ckanQueryApi).packageSearch(eq("en"), requestCaptor.capture());
+        assertThat(requestCaptor.getValue().getFq())
+                .isEqualTo("tags:(\"COVID\") AND " + CKAN_DATASET_TYPE_FILTER);
+    }
+
+    @Test
+    void searchByDatasetIdsAddsDatasetTypeFilter() {
+        var ckanQueryApi = mock(CkanQueryApi.class);
+        var mapper = mock(CkanDatasetsMapper.class);
+        when(ckanQueryApi.packageSearch(eq("en"), any(PackageSearchRequest.class))).thenReturn(
+                PackagesSearchResponse.builder()
+                        .result(PackagesSearchResult.builder().count(0).results(List.of()).build())
+                        .build());
+        when(mapper.map(any(PackagesSearchResult.class))).thenReturn(List.of());
+
+        var repository = new CkanDatasetsRepository(ckanQueryApi, mapper);
+
+        repository.search(Set.of("dataset-1"), null, 10, 0, null, "en");
+
+        var requestCaptor = ArgumentCaptor.forClass(PackageSearchRequest.class);
+        verify(ckanQueryApi).packageSearch(eq("en"), requestCaptor.capture());
+        assertThat(requestCaptor.getValue().getFq())
+                .isEqualTo("identifier:(\"dataset-1\") AND " + CKAN_DATASET_TYPE_FILTER);
+    }
+}

--- a/src/test/java/io/github/genomicdatainfrastructure/discovery/filters/infrastructure/ckan/CkanFilterBuilderTest.java
+++ b/src/test/java/io/github/genomicdatainfrastructure/discovery/filters/infrastructure/ckan/CkanFilterBuilderTest.java
@@ -5,6 +5,7 @@
 package io.github.genomicdatainfrastructure.discovery.filters.infrastructure.ckan;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static io.github.genomicdatainfrastructure.discovery.datasets.infrastructure.ckan.config.CkanConfiguration.CKAN_DATASET_TYPE_FILTER;
 
 import io.github.genomicdatainfrastructure.discovery.filters.infrastructure.quarkus.DatasetsConfig;
 import io.github.genomicdatainfrastructure.discovery.model.Filter;
@@ -142,6 +143,21 @@ class CkanFilterBuilderTest {
         assertThat(tags.getType()).isEqualTo(FilterType.FREE_TEXT);
     }
 
+    @Test
+    void limitsFilterDiscoveryToDatasets() {
+        var response = PackagesSearchResponse.builder()
+                .result(PackagesSearchResult.builder().searchFacets(Map.of()).build())
+                .build();
+
+        var stubApi = new StubCkanQueryApi(response);
+        var builder = new CkanFilterBuilder(stubApi, datasetsConfig);
+
+        builder.build(null, "en");
+
+        assertThat(stubApi.getLastRequest()).isNotNull();
+        assertThat(stubApi.getLastRequest().getFq()).isEqualTo(CKAN_DATASET_TYPE_FILTER);
+    }
+
     private Filter findFilter(List<Filter> filters, String key) {
         return filters.stream()
                 .filter(filter -> key.equals(filter.getKey()))
@@ -153,6 +169,7 @@ class CkanFilterBuilderTest {
     private static final class StubCkanQueryApi implements CkanQueryApi {
 
         private final PackagesSearchResponse response;
+        private PackageSearchRequest lastRequest;
 
         private StubCkanQueryApi(PackagesSearchResponse response) {
             this.response = response;
@@ -161,6 +178,7 @@ class CkanFilterBuilderTest {
         @Override
         public PackagesSearchResponse packageSearch(String acceptLanguage,
                 PackageSearchRequest packageSearchRequest) {
+            this.lastRequest = packageSearchRequest;
             return response;
         }
 
@@ -173,6 +191,10 @@ class CkanFilterBuilderTest {
         @Override
         public String retrieveDatasetInFormat(String id, String format, String authorization) {
             throw new UnsupportedOperationException();
+        }
+
+        private PackageSearchRequest getLastRequest() {
+            return lastRequest;
         }
     }
 

--- a/src/test/java/io/github/genomicdatainfrastructure/discovery/filters/infrastructure/ckan/CkanFiltersRepositoryTest.java
+++ b/src/test/java/io/github/genomicdatainfrastructure/discovery/filters/infrastructure/ckan/CkanFiltersRepositoryTest.java
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: 2026 PNED G.I.E.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package io.github.genomicdatainfrastructure.discovery.filters.infrastructure.ckan;
+
+import static io.github.genomicdatainfrastructure.discovery.datasets.infrastructure.ckan.config.CkanConfiguration.CKAN_DATASET_TYPE_FILTER;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.github.genomicdatainfrastructure.discovery.filters.infrastructure.mapper.CkanFilterMapper;
+import io.github.genomicdatainfrastructure.discovery.remote.ckan.api.CkanQueryApi;
+import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.PackageSearchRequest;
+import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.PackagesSearchResponse;
+import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.PackagesSearchResult;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class CkanFiltersRepositoryTest {
+
+    @Test
+    void getValuesForFilterAddsDatasetTypeConstraint() {
+        var ckanQueryApi = mock(CkanQueryApi.class);
+        var mapper = mock(CkanFilterMapper.class);
+        when(ckanQueryApi.packageSearch(eq("en"), any(PackageSearchRequest.class))).thenReturn(
+                PackagesSearchResponse.builder()
+                        .result(PackagesSearchResult.builder().build())
+                        .build());
+        when(mapper.map(any(PackagesSearchResponse.class), eq("tags"))).thenReturn(List.of());
+
+        var repository = new CkanFiltersRepository(ckanQueryApi, mapper);
+
+        repository.getValuesForFilter("tags", "en");
+
+        var requestCaptor = ArgumentCaptor.forClass(PackageSearchRequest.class);
+        verify(ckanQueryApi).packageSearch(eq("en"), requestCaptor.capture());
+        assertThat(requestCaptor.getValue().getFq()).isEqualTo(CKAN_DATASET_TYPE_FILTER);
+        assertThat(requestCaptor.getValue().getFacetField()).isEqualTo("[\"tags\"]");
+    }
+}


### PR DESCRIPTION
## Summary
- add a shared CKAN dataset type filter helper
- apply the dataset-only filter to CKAN dataset searches, ID collection, and filter queries
- add targeted tests covering the new CKAN `fq` behavior

## Testing
- mvn -q -Dtest=CkanFilterBuilderTest,CkanFiltersRepositoryTest,CkanDatasetsRepositoryTest,CkanDatasetIdsCollectorTest test

## Summary by Sourcery

Restrict CKAN-based discovery to dataset records by enforcing a shared dataset-type filter across searches, ID collection, and filter facet queries.

New Features:
- Introduce a reusable CKAN dataset-type filter helper for composing filter query strings.

Enhancements:
- Apply the dataset-type filter when performing CKAN dataset searches, dataset ID collection, and filter facet retrieval so that only datasets are considered.

Tests:
- Add unit tests verifying that the CKAN dataset-type filter is applied to filter-builder facet discovery, dataset searches, dataset ID collection, and filter value retrieval.