### PR TITLE
feat: add range query handling for min/max typical age

### DIFF
--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/persistence/CkanFacetsQueryBuilder.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/persistence/CkanFacetsQueryBuilder.java
@@ -136,9 +136,12 @@ public class CkanFacetsQueryBuilder {
         var upper = findValueByOperator(numericFacets, Operator.LESS_THAN_OR_EQUAL_TO_SYMBOL,
                 Operator.LESS_THAN_SYMBOL);
 
-        // since we're dealing with the range overlap explained below, both lower and upper bounds are needed
-        if (lower.isEmpty() || upper.isEmpty()) {
-            return Optional.empty();
+        if (lower.isPresent() && upper.isEmpty()) {
+            return resolveNumberCondition(numericFacets)
+                    .flatMap(condition -> condition.toSolrQuery("min_typical_age"));
+        } else if (upper.isPresent() && lower.isEmpty()) {
+            return resolveNumberCondition(numericFacets)
+                    .flatMap(condition -> condition.toSolrQuery("max_typical_age"));
         }
 
         var sb = new StringBuilder();

--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/persistence/CkanFacetsQueryBuilder.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/persistence/CkanFacetsQueryBuilder.java
@@ -29,6 +29,7 @@ public class CkanFacetsQueryBuilder {
     private static final String RANGE_PATTERN = "%s:[%s TO %s]";
     private static final String RANGE_WILDCARD = "*";
     private static final String AND = " AND ";
+    private static final String TYPICAL_AGE_KEY = "typical_age";
 
     public String buildFacetQuery(DatasetSearchQuery query) {
         var operator = CkanQueryOperatorMapper.getOperator(query.getOperator());
@@ -118,8 +119,55 @@ public class CkanFacetsQueryBuilder {
 
     private Optional<String> buildNumberRangeQuery(String key,
             List<DatasetSearchQueryFacet> facets) {
+        if (TYPICAL_AGE_KEY.equals(key)) {
+            return buildTypicalAgeQuery(facets);
+        }
+
         return resolveNumberCondition(facets)
                 .flatMap(condition -> condition.toSolrQuery(key));
+    }
+
+    private Optional<String> buildTypicalAgeQuery(List<DatasetSearchQueryFacet> facets) {
+        var numericFacets = facets.stream()
+                .filter(facet -> FilterType.NUMBER.equals(facet.getType()))
+                .toList();
+        var lower = findValueByOperator(numericFacets, Operator.GREATER_THAN_SYMBOL,
+                Operator.GREATER_THAN_OR_EQUAL_TO_SYMBOL);
+        var upper = findValueByOperator(numericFacets, Operator.LESS_THAN_OR_EQUAL_TO_SYMBOL,
+                Operator.LESS_THAN_SYMBOL);
+
+        // since we're dealing with the range overlap explained below, both lower and upper bounds are needed
+        if (lower.isEmpty() || upper.isEmpty()) {
+            return Optional.empty();
+        }
+
+        var sb = new StringBuilder();
+
+        // The mapping of lower/upper search bounds to max/min_typical_age respectively is intentional,
+        // and is required to correctly identify datasets whose typical age range overlaps with the search range.
+        //
+        // A naive approach would map the search lower bound to min_typical_age and the search upper bound to
+        // max_typical_age — but this would only match datasets whose age range is fully contained within the
+        // search range, missing datasets that only partially overlap.
+        //
+        // Instead, we use the overlap condition: two ranges [A, B] and [C, D] overlap if and only if A <= D && C <= B.
+        // Applied here: the search range is [lower, upper] and the dataset range is [min_typical_age, max_typical_age].
+        // Overlap occurs when:
+        //   - lower <= max_typical_age  (the search range starts before the dataset range ends)
+        //   - min_typical_age <= upper  (the dataset range starts before the search range ends)
+        upper.flatMap(value -> new NumberCondition(null, value, null).toSolrQuery(
+                "min_typical_age"))
+                .ifPresent(sb::append);
+        lower.flatMap(value -> new NumberCondition(value, null, null).toSolrQuery(
+                "max_typical_age"))
+                .ifPresent(value -> {
+                    if (!sb.isEmpty()) {
+                        sb.append(AND);
+                    }
+                    sb.append(value);
+                });
+
+        return Optional.of(sb.toString());
     }
 
     private Optional<NumberCondition> resolveNumberCondition(List<DatasetSearchQueryFacet> facets) {

--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/persistence/CkanFacetsQueryBuilder.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/persistence/CkanFacetsQueryBuilder.java
@@ -140,10 +140,10 @@ public class CkanFacetsQueryBuilder {
 
         if (lower.isPresent() && upper.isEmpty()) {
             return resolveNumberCondition(numericFacets)
-                    .flatMap(condition -> condition.toSolrQuery(MIN_TYPICAL_AGE));
+                    .flatMap(condition -> condition.toSolrQuery(MAX_TYPICAL_AGE));
         } else if (upper.isPresent() && lower.isEmpty()) {
             return resolveNumberCondition(numericFacets)
-                    .flatMap(condition -> condition.toSolrQuery(MAX_TYPICAL_AGE));
+                    .flatMap(condition -> condition.toSolrQuery(MIN_TYPICAL_AGE));
         }
 
         var sb = new StringBuilder();

--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/persistence/CkanFacetsQueryBuilder.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/persistence/CkanFacetsQueryBuilder.java
@@ -30,6 +30,8 @@ public class CkanFacetsQueryBuilder {
     private static final String RANGE_WILDCARD = "*";
     private static final String AND = " AND ";
     private static final String TYPICAL_AGE_KEY = "typical_age";
+    private static final String MIN_TYPICAL_AGE = "min_typical_age";
+    private static final String MAX_TYPICAL_AGE = "max_typical_age";
 
     public String buildFacetQuery(DatasetSearchQuery query) {
         var operator = CkanQueryOperatorMapper.getOperator(query.getOperator());
@@ -138,10 +140,10 @@ public class CkanFacetsQueryBuilder {
 
         if (lower.isPresent() && upper.isEmpty()) {
             return resolveNumberCondition(numericFacets)
-                    .flatMap(condition -> condition.toSolrQuery("min_typical_age"));
+                    .flatMap(condition -> condition.toSolrQuery(MIN_TYPICAL_AGE));
         } else if (upper.isPresent() && lower.isEmpty()) {
             return resolveNumberCondition(numericFacets)
-                    .flatMap(condition -> condition.toSolrQuery("max_typical_age"));
+                    .flatMap(condition -> condition.toSolrQuery(MAX_TYPICAL_AGE));
         }
 
         var sb = new StringBuilder();
@@ -159,10 +161,10 @@ public class CkanFacetsQueryBuilder {
         //   - lower <= max_typical_age  (the search range starts before the dataset range ends)
         //   - min_typical_age <= upper  (the dataset range starts before the search range ends)
         upper.flatMap(value -> new NumberCondition(null, value, null).toSolrQuery(
-                "min_typical_age"))
+                MIN_TYPICAL_AGE))
                 .ifPresent(sb::append);
         lower.flatMap(value -> new NumberCondition(value, null, null).toSolrQuery(
-                "max_typical_age"))
+                MAX_TYPICAL_AGE))
                 .ifPresent(value -> {
                     if (!sb.isEmpty()) {
                         sb.append(AND);
@@ -170,6 +172,9 @@ public class CkanFacetsQueryBuilder {
                     sb.append(value);
                 });
 
+        if (sb.isEmpty()) {
+            return Optional.empty();
+        }
         return Optional.of(sb.toString());
     }
 

--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/filters/infrastructure/ckan/CkanSearchFacetsMapper.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/filters/infrastructure/ckan/CkanSearchFacetsMapper.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -109,10 +110,12 @@ public class CkanSearchFacetsMapper {
             // Processing a composite range facet. We'll gather individual components and combine them into the
             // composite facet.
             var items = new ArrayList<CkanValueLabel>();
+            var titles = new LinkedHashSet<String>();
 
             for (var component : metadata.rangeComposite) {
                 var componentFacet = facets.get(component);
                 items.addAll(componentFacet.getItems());
+                titles.add(componentFacet.getTitle());
 
                 // skip processing the individual components
                 skipList.add(component);
@@ -120,6 +123,7 @@ public class CkanSearchFacetsMapper {
 
             // replace the items (values) for the composite facet with the values collected from the individual facets
             facet.items(items);
+            facet.setTitle(String.join(" - ", titles));
         }
 
         if (metadata != null && FilterType.DATETIME.equals(metadata.type)) {

--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/filters/infrastructure/ckan/CkanSearchFacetsMapper.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/filters/infrastructure/ckan/CkanSearchFacetsMapper.java
@@ -17,8 +17,10 @@ import jakarta.enterprise.context.ApplicationScoped;
 import java.math.BigDecimal;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -60,10 +62,12 @@ public class CkanSearchFacetsMapper {
 
     private List<Filter> filters(Map<String, CkanFacet> facets) {
         var filtersByKey = new LinkedHashMap<String, Filter>();
+        var processedKeys = new HashSet<String>();
 
         facets.entrySet()
                 .stream()
-                .map(this::filter)
+                .filter(entry -> !processedKeys.contains(entry.getKey()))
+                .map(f -> this.filter(f, facets, processedKeys))
                 .filter(Objects::nonNull)
                 .forEach(filter -> filtersByKey.put(filter.getKey(), filter));
 
@@ -82,11 +86,42 @@ public class CkanSearchFacetsMapper {
         return List.copyOf(filtersByKey.values());
     }
 
-    private Filter filter(Map.Entry<String, CkanFacet> entry) {
+    private Filter filter(Map.Entry<String, CkanFacet> entry, Map<String, CkanFacet> facets,
+                          Set<String> skipList) {
         var key = entry.getKey();
         var facet = entry.getValue();
 
         var metadata = filtersMetadata.get(key);
+        if (metadata == null) {
+            // check if this is part of a range composite
+            var rangeComponentMatch = filtersMetadata.entrySet()
+                    .stream()
+                    .filter(e -> e.getValue().rangeComposite.contains(entry.getKey()))
+                    .findFirst();
+            if (rangeComponentMatch.isPresent()) {
+                var component = rangeComponentMatch.orElseThrow();
+                key = component.getKey();
+                metadata = component.getValue();
+            }
+        }
+
+        if (metadata != null && !metadata.rangeComposite.isEmpty()) {
+            // Processing a composite range facet. We'll gather individual components and combine them into the
+            // composite facet.
+            var items = new ArrayList<CkanValueLabel>();
+
+            for (var component : metadata.rangeComposite) {
+                var componentFacet = facets.get(component);
+                items.addAll(componentFacet.getItems());
+
+                // skip processing the individual components
+                skipList.add(component);
+            }
+
+            // replace the items (values) for the composite facet with the values collected from the individual facets
+            facet.items(items);
+        }
+
         if (metadata != null && FilterType.DATETIME.equals(metadata.type)) {
             return buildDateTimeFilter(key, facet, metadata.group);
         }
@@ -244,12 +279,13 @@ public class CkanSearchFacetsMapper {
                         .map(filter -> Map.entry(filter.key(),
                                 new FilterMetadata(Optional.ofNullable(filter.type())
                                         .orElse(DEFAULT_FILTER_TYPE),
-                                        group.key()))))
+                                        group.key(),
+                                        filter.rangeComposite().orElse(Set.of())))))
                 .collect(java.util.stream.Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue,
                         (left, right) -> right, LinkedHashMap::new));
     }
 
-    private record FilterMetadata(FilterType type, String group) {
+    private record FilterMetadata(FilterType type, String group, Set<String> rangeComposite) {
     }
 
     private record NumericBound(BigDecimal numeric, String raw) {

--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/filters/infrastructure/ckan/CkanSearchFacetsMapper.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/filters/infrastructure/ckan/CkanSearchFacetsMapper.java
@@ -87,7 +87,7 @@ public class CkanSearchFacetsMapper {
     }
 
     private Filter filter(Map.Entry<String, CkanFacet> entry, Map<String, CkanFacet> facets,
-                          Set<String> skipList) {
+            Set<String> skipList) {
         var key = entry.getKey();
         var facet = entry.getValue();
 

--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/filters/infrastructure/quarkus/DatasetsConfig.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/filters/infrastructure/quarkus/DatasetsConfig.java
@@ -8,6 +8,7 @@ import io.github.genomicdatainfrastructure.discovery.model.FilterType;
 import io.smallrye.config.ConfigMapping;
 import io.smallrye.config.WithDefault;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 @ConfigMapping(prefix = "datasets")
@@ -33,5 +34,7 @@ public interface DatasetsConfig {
 
         @WithDefault("DROPDOWN")
         FilterType type();
+
+        Optional<Set<String>> rangeComposite();
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -70,7 +70,7 @@ quarkus.otel.metrics.enabled=true
 # Custom Application Properties
 sources.beacon=true
 app.accept-language.default=en-GB
-datasets.filters=access_rights,theme,tags,publisher_name,res_format,modified,number_of_records
+datasets.filters=access_rights,theme,tags,publisher_name,res_format,modified,number_of_records,min_typical_age,max_typical_age
 datasets.no-group-key=NO_GROUP
 datasets.filter-groups[0].key=DEFAULT
 datasets.filter-groups[0].filters[0].key=access_rights
@@ -82,6 +82,9 @@ datasets.filter-groups[0].filters[5].key=modified
 datasets.filter-groups[0].filters[5].type=datetime
 datasets.filter-groups[0].filters[6].key=number_of_records
 datasets.filter-groups[0].filters[6].type=number
+datasets.filter-groups[0].filters[7].key=typical_age
+datasets.filter-groups[0].filters[7].type=number
+datasets.filter-groups[0].filters[7].range-composite=min_typical_age,max_typical_age
 
 # Development Profile Specific Configuration
 %dev.quarkus.oidc.auth-server-url=https://id.portal.dev.gdi.lu/realms/gdi

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -70,7 +70,7 @@ quarkus.otel.metrics.enabled=true
 # Custom Application Properties
 sources.beacon=true
 app.accept-language.default=en-GB
-datasets.filters=access_rights,theme,tags,publisher_name,res_format,modified,number_of_records,min_typical_age,max_typical_age
+datasets.filters=access_rights,theme,tags,publisher_name,res_format,modified,number_of_records
 datasets.no-group-key=NO_GROUP
 datasets.filter-groups[0].key=DEFAULT
 datasets.filter-groups[0].filters[0].key=access_rights
@@ -82,9 +82,6 @@ datasets.filter-groups[0].filters[5].key=modified
 datasets.filter-groups[0].filters[5].type=datetime
 datasets.filter-groups[0].filters[6].key=number_of_records
 datasets.filter-groups[0].filters[6].type=number
-datasets.filter-groups[0].filters[7].key=typical_age
-datasets.filter-groups[0].filters[7].type=number
-datasets.filter-groups[0].filters[7].range-composite=min_typical_age,max_typical_age
 
 # Development Profile Specific Configuration
 %dev.quarkus.oidc.auth-server-url=https://id.portal.dev.gdi.lu/realms/gdi

--- a/src/test/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/CkanFacetsQueryBuilderTest.java
+++ b/src/test/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/CkanFacetsQueryBuilderTest.java
@@ -397,7 +397,7 @@ class CkanFacetsQueryBuilderTest {
                 ))
                 .build();
 
-        var expected = "min_typical_age:[10 TO *]";
+        var expected = "max_typical_age:[10 TO *]";
         var actual = CkanFacetsQueryBuilder.buildFacetQuery(query);
 
         assertEquals(expected, actual);
@@ -417,7 +417,7 @@ class CkanFacetsQueryBuilderTest {
                 ))
                 .build();
 
-        var expected = "max_typical_age:[* TO 100]";
+        var expected = "min_typical_age:[* TO 100]";
         var actual = CkanFacetsQueryBuilder.buildFacetQuery(query);
 
         assertEquals(expected, actual);

--- a/src/test/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/CkanFacetsQueryBuilderTest.java
+++ b/src/test/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/CkanFacetsQueryBuilderTest.java
@@ -321,4 +321,105 @@ class CkanFacetsQueryBuilderTest {
 
         assertEquals(expected, actual);
     }
+
+    @Test
+    void canParse_withTypicalAgeRangeFacet() {
+        var query = DatasetSearchQuery.builder()
+                .facets(List.of(
+                        DatasetSearchQueryFacet.builder()
+                                .source("ckan")
+                                .type(FilterType.NUMBER)
+                                .key("typical_age")
+                                .operator(Operator.GREATER_THAN_OR_EQUAL_TO_SYMBOL)
+                                .value("0")
+                                .build(),
+                        DatasetSearchQueryFacet.builder()
+                                .source("ckan")
+                                .type(FilterType.NUMBER)
+                                .key("typical_age")
+                                .operator(Operator.LESS_THAN_OR_EQUAL_TO_SYMBOL)
+                                .value("100")
+                                .build()
+                ))
+                .build();
+
+        var expected = "min_typical_age:[* TO 100] AND max_typical_age:[0 TO *]";
+        var actual = CkanFacetsQueryBuilder.buildFacetQuery(query);
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void canParse_withTypicalAgeRangeAndNumberOfRecordsFacet() {
+        var query = DatasetSearchQuery.builder()
+                .facets(List.of(
+                        DatasetSearchQueryFacet.builder()
+                                .source("ckan")
+                                .type(FilterType.NUMBER)
+                                .key("typical_age")
+                                .operator(Operator.GREATER_THAN_OR_EQUAL_TO_SYMBOL)
+                                .value("0")
+                                .build(),
+                        DatasetSearchQueryFacet.builder()
+                                .source("ckan")
+                                .type(FilterType.NUMBER)
+                                .key("typical_age")
+                                .operator(Operator.LESS_THAN_OR_EQUAL_TO_SYMBOL)
+                                .value("100")
+                                .build(),
+                        DatasetSearchQueryFacet.builder()
+                                .source("ckan")
+                                .type(FilterType.NUMBER)
+                                .key("number_of_records")
+                                .operator(Operator.EQUAL_SYMBOL)
+                                .value("15")
+                                .build()
+                ))
+                .build();
+
+        var expected = "min_typical_age:[* TO 100] AND max_typical_age:[0 TO *] AND number_of_records:(15)";
+        var actual = CkanFacetsQueryBuilder.buildFacetQuery(query);
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void canParse_withTypicalAgeLowerBoundFacet() {
+        var query = DatasetSearchQuery.builder()
+                .facets(List.of(
+                        DatasetSearchQueryFacet.builder()
+                                .source("ckan")
+                                .type(FilterType.NUMBER)
+                                .key("typical_age")
+                                .operator(Operator.GREATER_THAN_OR_EQUAL_TO_SYMBOL)
+                                .value("0")
+                                .build()
+                ))
+                .build();
+
+        var expected = "";
+        var actual = CkanFacetsQueryBuilder.buildFacetQuery(query);
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void canParse_withTypicalAgeUpperBoundFacet() {
+        var query = DatasetSearchQuery.builder()
+                .facets(List.of(
+                        DatasetSearchQueryFacet.builder()
+                                .source("ckan")
+                                .type(FilterType.NUMBER)
+                                .key("typical_age")
+                                .operator(Operator.LESS_THAN_OR_EQUAL_TO_SYMBOL)
+                                .value("0")
+                                .build()
+                ))
+                .build();
+
+        var expected = "";
+        var actual = CkanFacetsQueryBuilder.buildFacetQuery(query);
+
+        assertEquals(expected, actual);
+    }
 }

--- a/src/test/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/CkanFacetsQueryBuilderTest.java
+++ b/src/test/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/CkanFacetsQueryBuilderTest.java
@@ -392,12 +392,12 @@ class CkanFacetsQueryBuilderTest {
                                 .type(FilterType.NUMBER)
                                 .key("typical_age")
                                 .operator(Operator.GREATER_THAN_OR_EQUAL_TO_SYMBOL)
-                                .value("0")
+                                .value("10")
                                 .build()
                 ))
                 .build();
 
-        var expected = "";
+        var expected = "min_typical_age:[10 TO *]";
         var actual = CkanFacetsQueryBuilder.buildFacetQuery(query);
 
         assertEquals(expected, actual);
@@ -412,12 +412,12 @@ class CkanFacetsQueryBuilderTest {
                                 .type(FilterType.NUMBER)
                                 .key("typical_age")
                                 .operator(Operator.LESS_THAN_OR_EQUAL_TO_SYMBOL)
-                                .value("0")
+                                .value("100")
                                 .build()
                 ))
                 .build();
 
-        var expected = "";
+        var expected = "max_typical_age:[* TO 100]";
         var actual = CkanFacetsQueryBuilder.buildFacetQuery(query);
 
         assertEquals(expected, actual);

--- a/src/test/java/io/github/genomicdatainfrastructure/discovery/filters/application/usecases/RetrieveFiltersQueryTest.java
+++ b/src/test/java/io/github/genomicdatainfrastructure/discovery/filters/application/usecases/RetrieveFiltersQueryTest.java
@@ -11,6 +11,8 @@ import io.github.genomicdatainfrastructure.discovery.model.Filter;
 import io.github.genomicdatainfrastructure.discovery.model.FilterType;
 import io.github.genomicdatainfrastructure.discovery.model.ValueLabel;
 import jakarta.enterprise.inject.Instance;
+
+import java.util.Optional;
 import java.util.Set;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -232,6 +234,11 @@ class RetrieveFiltersQueryTest {
         @Override
         public FilterType type() {
             return FilterType.DROPDOWN;
+        }
+
+        @Override
+        public Optional<Set<String>> rangeComposite() {
+            return Optional.empty();
         }
     }
 }

--- a/src/test/java/io/github/genomicdatainfrastructure/discovery/filters/infrastructure/ckan/CkanFilterBuilderTest.java
+++ b/src/test/java/io/github/genomicdatainfrastructure/discovery/filters/infrastructure/ckan/CkanFilterBuilderTest.java
@@ -17,10 +17,12 @@ import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.PackageSe
 import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.PackagesSearchResponse;
 import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.PackagesSearchResult;
 import jakarta.enterprise.inject.Vetoed;
+
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+
 import org.junit.jupiter.api.Test;
 
 class CkanFilterBuilderTest {
@@ -103,7 +105,7 @@ class CkanFilterBuilderTest {
                 .result(PackagesSearchResult.builder()
                         .searchFacets(Map.of(
                                 "min_typical_age", CkanFacet.builder()
-                                        .title("Minimal Typical Age")
+                                        .title("Minimum Typical Age")
                                         .items(List.of(CkanValueLabel.builder()
                                                 .name("0")
                                                 .displayName("0")
@@ -137,6 +139,7 @@ class CkanFilterBuilderTest {
         var filters = builder.build(null, "en");
 
         var typicalAge = findFilter(filters, "typical_age");
+        assertThat(typicalAge.getLabel()).isEqualTo("Minimum Typical Age - Maximum Typical Age");
         assertThat(typicalAge.getType()).isEqualTo(FilterType.NUMBER);
         assertThat(typicalAge.getRange()).isNotNull();
         assertThat(typicalAge.getRange().getMin()).isEqualTo("0");
@@ -233,7 +236,8 @@ class CkanFilterBuilderTest {
                 new TestFilter("number_of_records", FilterType.NUMBER),
                 new TestFilter("tags", FilterType.DROPDOWN),
                 new TestFilter("typical_age", FilterType.NUMBER, Optional.of(Set.of(
-                        "min_typical_age", "max_typical_age"))));
+                        "min_typical_age", "max_typical_age"))
+                ));
 
         @Override
         public String filters() {

--- a/src/test/java/io/github/genomicdatainfrastructure/discovery/filters/infrastructure/ckan/CkanFilterBuilderTest.java
+++ b/src/test/java/io/github/genomicdatainfrastructure/discovery/filters/infrastructure/ckan/CkanFilterBuilderTest.java
@@ -98,6 +98,52 @@ class CkanFilterBuilderTest {
     }
 
     @Test
+    void buildRangeMetadataForCompositeFacet() {
+        var response = PackagesSearchResponse.builder()
+                .result(PackagesSearchResult.builder()
+                        .searchFacets(Map.of(
+                                "min_typical_age", CkanFacet.builder()
+                                        .title("Minimal Typical Age")
+                                        .items(List.of(CkanValueLabel.builder()
+                                                .name("0")
+                                                .displayName("0")
+                                                .count(1)
+                                                .build(),
+                                                CkanValueLabel.builder()
+                                                        .name("10")
+                                                        .displayName("10")
+                                                        .count(2)
+                                                        .build()))
+                                        .build(),
+                                "max_typical_age", CkanFacet.builder()
+                                        .title("Maximum Typical Age")
+                                        .items(List.of(CkanValueLabel.builder()
+                                                .name("100")
+                                                .displayName("100")
+                                                .count(3)
+                                                .build(),
+                                                CkanValueLabel.builder()
+                                                        .name("110")
+                                                        .displayName("110")
+                                                        .count(4)
+                                                        .build()))
+                                        .build()
+                        ))
+                        .build())
+                .build();
+
+        var builder = new CkanFilterBuilder(new StubCkanQueryApi(response),
+                new CkanSearchFacetsMapper(datasetsConfig));
+        var filters = builder.build(null, "en");
+
+        var typicalAge = findFilter(filters, "typical_age");
+        assertThat(typicalAge.getType()).isEqualTo(FilterType.NUMBER);
+        assertThat(typicalAge.getRange()).isNotNull();
+        assertThat(typicalAge.getRange().getMin()).isEqualTo("0");
+        assertThat(typicalAge.getRange().getMax()).isEqualTo("110");
+    }
+
+    @Test
     void leavesRangeEmptyWhenFacetItemsAreNotParsable() {
         var response = PackagesSearchResponse.builder()
                 .result(PackagesSearchResult.builder()
@@ -185,11 +231,13 @@ class CkanFilterBuilderTest {
         private static final Set<Filter> FILTERS = Set.of(
                 new TestFilter("modified", FilterType.DATETIME),
                 new TestFilter("number_of_records", FilterType.NUMBER),
-                new TestFilter("tags", FilterType.DROPDOWN));
+                new TestFilter("tags", FilterType.DROPDOWN),
+                new TestFilter("typical_age", FilterType.NUMBER, Optional.of(Set.of(
+                        "min_typical_age", "max_typical_age"))));
 
         @Override
         public String filters() {
-            return "modified,number_of_records,tags";
+            return "modified,number_of_records,tags,min_typical_age,max_typical_age";
         }
 
         @Override
@@ -224,7 +272,12 @@ class CkanFilterBuilderTest {
     }
 
     @Vetoed
-    private record TestFilter(String key, FilterType type) implements DatasetsConfig.Filter {
+    private record TestFilter(String key, FilterType type, Optional<Set<String>> rangeComposite)
+            implements DatasetsConfig.Filter {
+
+        TestFilter(String key, FilterType type) {
+            this(key, type, Optional.empty());
+        }
 
         @Override
         public String key() {
@@ -234,11 +287,6 @@ class CkanFilterBuilderTest {
         @Override
         public FilterType type() {
             return type;
-        }
-
-        @Override
-        public Optional<Set<String>> rangeComposite() {
-            return Optional.empty();
         }
     }
 

--- a/src/test/java/io/github/genomicdatainfrastructure/discovery/filters/infrastructure/ckan/CkanFilterBuilderTest.java
+++ b/src/test/java/io/github/genomicdatainfrastructure/discovery/filters/infrastructure/ckan/CkanFilterBuilderTest.java
@@ -19,6 +19,7 @@ import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.PackagesS
 import jakarta.enterprise.inject.Vetoed;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 
@@ -234,6 +235,11 @@ class CkanFilterBuilderTest {
         public FilterType type() {
             return type;
         }
+
+        @Override
+        public Optional<Set<String>> rangeComposite() {
+            return Optional.empty();
+        }
     }
 
     @Vetoed
@@ -247,6 +253,11 @@ class CkanFilterBuilderTest {
         @Override
         public FilterType type() {
             return FilterType.FREE_TEXT;
+        }
+
+        @Override
+        public Optional<Set<String>> rangeComposite() {
+            return Optional.empty();
         }
     }
 


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: 2024 PNED G.I.E. -->

<!-- SPDX-License-Identifier: Apache-2.0 -->

## 🚀 Pull Request Checklist

- **Title:**

  - `[ ]` A brief, descriptive title for the changes.

- **Description:**

  - `[ ]` Provide a clear and concise description of your pull request, including the purpose of the changes and the approach you've taken.

- **Context:**

  - `[ ]` Why are these changes necessary? What problem do they solve? Link any related issues.

- **Changes:**

  - `[ ]` List the major changes you've made, ideally organized by commit or feature.

- **Testing:**

  - `[ ]` Describe how the changes have been tested. Include any relevant details about the testing environment and the test cases.

- **Screenshots (if applicable):**

  - `[ ]` If your changes are visual, include screenshots to help explain your changes.

- **Additional Information:**

  - `[ ]` Add any other information that might be useful for reviewers, such as considerations, discussions, or dependencies.

- **Checklist:**
  - `[ ]` I have checked that my code adheres to the project's style guidelines and that my code is well-commented.
  - `[ ]` I have performed self-review of my own code and corrected any misspellings.
  - `[ ]` I have made corresponding changes to the documentation (if applicable).
  - `[ ]` My changes generate no new warnings or errors.
  - `[ ]` I have added tests that prove my fix is effective or that my feature works.
  - `[ ]` New and existing unit tests pass locally with my changes.

## Summary by Sourcery

Handle typical age numeric range facets as overlapping min/max typical age ranges in CKAN facet queries.

New Features:
- Support querying datasets by typical age range using min_typical_age and max_typical_age overlap semantics in CKAN facet queries.

Tests:
- Add unit tests covering typical_age range queries, combinations with other numeric facets, and behavior when only a single bound is provided.