### PR TITLE
Revert array url of contact point

### DIFF
--- a/src/main/openapi/ckan.yaml
+++ b/src/main/openapi/ckan.yaml
@@ -439,11 +439,9 @@ components:
           type: string
           title: email
         url:
-          type: array
           title: url
           description: URLs for more information about the contact point.
-          items:
-            type: string
+          type: string
         identifier:
           type: string
           title: identifier

--- a/src/main/openapi/discovery.yaml
+++ b/src/main/openapi/discovery.yaml
@@ -891,11 +891,9 @@ components:
           type: string
           title: email
         url:
-          type: array
           title: url
           description: URLs for more information about the contact point.
-          items:
-            type: string
+          type: string
         identifier:
           type: string
           title: identifier

--- a/src/test/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/mapper/CkanDatasetsMapperTest.java
+++ b/src/test/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/mapper/CkanDatasetsMapperTest.java
@@ -193,13 +193,13 @@ class CkanDatasetsMapperTest {
                                     .name("Contact 1")
                                     .email("contact1@example.com")
                                     .identifier("contact-identifier-1")
-                                    .url(List.of("http://example.com/contact-1"))
+                                    .url("http://example.com/contact-1")
                                     .build(),
                             ContactPoint.builder()
                                     .name("Contact 2")
                                     .email("contact2@example.com")
                                     .identifier("contact-identifier-2")
-                                    .url(List.of("http://example.com/contact-2"))
+                                    .url("http://example.com/contact-2")
                                     .build()
                     ))
                     .datasetRelationships(List.of(
@@ -471,13 +471,13 @@ class CkanDatasetsMapperTest {
                                 .name("Contact 1")
                                 .email("contact1@example.com")
                                 .identifier("contact-identifier-1")
-                                .url(List.of("http://example.com/contact-1"))
+                                .url("http://example.com/contact-1")
                                 .build(),
                         CkanContactPoint.builder()
                                 .name("Contact 2")
                                 .email("contact2@example.com")
                                 .identifier("contact-identifier-2")
-                                .url(List.of("http://example.com/contact-2"))
+                                .url("http://example.com/contact-2")
                                 .build()
                 ))
                 .creator(List.of(


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: 2024 PNED G.I.E. -->

<!-- SPDX-License-Identifier: Apache-2.0 -->

## 🚀 Pull Request Checklist

- **Title:**

  - `[ ]` A brief, descriptive title for the changes.

- **Description:**

  - `[ ]` Provide a clear and concise description of your pull request, including the purpose of the changes and the approach you've taken.

- **Context:**

  - `[ ]` Why are these changes necessary? What problem do they solve? Link any related issues.

- **Changes:**

  - `[ ]` List the major changes you've made, ideally organized by commit or feature.

- **Testing:**

  - `[ ]` Describe how the changes have been tested. Include any relevant details about the testing environment and the test cases.

- **Screenshots (if applicable):**

  - `[ ]` If your changes are visual, include screenshots to help explain your changes.

- **Additional Information:**

  - `[ ]` Add any other information that might be useful for reviewers, such as considerations, discussions, or dependencies.

- **Checklist:**
  - `[ ]` I have checked that my code adheres to the project's style guidelines and that my code is well-commented.
  - `[ ]` I have performed self-review of my own code and corrected any misspellings.
  - `[ ]` I have made corresponding changes to the documentation (if applicable).
  - `[ ]` My changes generate no new warnings or errors.
  - `[ ]` I have added tests that prove my fix is effective or that my feature works.
  - `[ ]` New and existing unit tests pass locally with my changes.

## Summary by Sourcery

Revert contact point URL back to a single string value across the CKAN discovery model and tests.

Enhancements:
- Align OpenAPI CKAN and discovery specifications to define contact point URL as a string instead of an array.

Tests:
- Update CKAN dataset mapper tests to expect a single string contact point URL rather than an array.