### PR TITLE
feat: enable single value deserialization for collection fields in JacksonConfig

### DIFF
--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/config/JacksonConfig.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/config/JacksonConfig.java
@@ -4,6 +4,7 @@
 
 package io.github.genomicdatainfrastructure.discovery.config;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.cfg.CoercionAction;
 import com.fasterxml.jackson.databind.cfg.CoercionInputShape;
@@ -26,6 +27,10 @@ public class JacksonConfig implements ObjectMapperCustomizer {
 
     @Override
     public void customize(ObjectMapper objectMapper) {
+        // Accept single values for collection fields when CKAN sends a string instead of an array
+        // (e.g. contact.url as "https://..." instead of ["https://..."])
+        objectMapper.enable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY);
+
         // For POJO types, coerce empty strings to null
         // This handles cases where CKAN returns "" instead of {} or null
         objectMapper.coercionConfigFor(LogicalType.POJO)


### PR DESCRIPTION
This change allows the ObjectMapper to accept single values for collection fields, addressing cases where CKAN sends a string instead of an array, such as contact.url.

<!-- SPDX-FileCopyrightText: 2024 PNED G.I.E. -->

<!-- SPDX-License-Identifier: Apache-2.0 -->

## 🚀 Pull Request Checklist

- **Title:**

  - `[ ]` A brief, descriptive title for the changes.

- **Description:**

  - `[ ]` Provide a clear and concise description of your pull request, including the purpose of the changes and the approach you've taken.

- **Context:**

  - `[ ]` Why are these changes necessary? What problem do they solve? Link any related issues.

- **Changes:**

  - `[ ]` List the major changes you've made, ideally organized by commit or feature.

- **Testing:**

  - `[ ]` Describe how the changes have been tested. Include any relevant details about the testing environment and the test cases.

- **Screenshots (if applicable):**

  - `[ ]` If your changes are visual, include screenshots to help explain your changes.

- **Additional Information:**

  - `[ ]` Add any other information that might be useful for reviewers, such as considerations, discussions, or dependencies.

- **Checklist:**
  - `[ ]` I have checked that my code adheres to the project's style guidelines and that my code is well-commented.
  - `[ ]` I have performed self-review of my own code and corrected any misspellings.
  - `[ ]` I have made corresponding changes to the documentation (if applicable).
  - `[ ]` My changes generate no new warnings or errors.
  - `[ ]` I have added tests that prove my fix is effective or that my feature works.
  - `[ ]` New and existing unit tests pass locally with my changes.

## Summary by Sourcery

New Features:
- Allow collection-typed fields to accept single JSON values by enabling Jackson's ACCEPT_SINGLE_VALUE_AS_ARRAY deserialization feature.