### PR TITLE
feat: add inSeriesCount mapping and related functionality to CkanDatasetsMapper

### DIFF
--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/mapper/CkanDatasetsMapper.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/mapper/CkanDatasetsMapper.java
@@ -171,6 +171,7 @@ public interface CkanDatasetsMapper {
     @Mapping(target = "numberOfUniqueIndividuals", source = "numberOfUniqueIndividuals")
     @Mapping(target = "temporalCoverage", source = "temporalCoverage")
     @Mapping(target = "distributionsCount", source = ".", qualifiedByName = "countDistributions")
+    @Mapping(target = "inSeriesCount", source = ".", qualifiedByName = "countInSeries")
     @Mapping(target = "catalogue", ignore = true)
     @Mapping(target = "recordsCount", ignore = true)
     SearchedDataset mapToSearchedDataset(CkanPackage ckanPackage);
@@ -338,6 +339,23 @@ public interface CkanDatasetsMapper {
     @Named("countDistributions")
     default int countDistributions(CkanPackage ckanPackage) {
         return filterDistributions(ckanPackage).size();
+    }
+
+    /**
+     * Counts unique dataset series references, ignoring null/blank values.
+     */
+    @Named("countInSeries")
+    default int countInSeries(CkanPackage ckanPackage) {
+        if (ckanPackage == null || ckanPackage.getInSeries() == null) {
+            return 0;
+        }
+
+        return (int) ckanPackage.getInSeries().stream()
+                .filter(Objects::nonNull)
+                .map(String::trim)
+                .filter(StringUtils::isNotBlank)
+                .distinct()
+                .count();
     }
 
     /**

--- a/src/main/openapi/discovery.yaml
+++ b/src/main/openapi/discovery.yaml
@@ -392,6 +392,9 @@ components:
         distributionsCount:
           type: integer
           title: Distributions count
+        inSeriesCount:
+          type: integer
+          title: Dataset series count
       required:
         - id
         - title

--- a/src/test/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/mapper/CkanDatasetsMapperTest.java
+++ b/src/test/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/mapper/CkanDatasetsMapperTest.java
@@ -620,7 +620,8 @@ class CkanDatasetsMapperTest {
                                 .build()
                 ))
                 .spatialResolutionInMeters(10.0f)
-                .alternateIdentifier(List.of("internalURI:admsIdentifier0"));
+                .alternateIdentifier(List.of("internalURI:admsIdentifier0"))
+                .inSeries(List.of("series-1", "series-2", "series-2", " "));
     }
 
     @Nested
@@ -678,6 +679,7 @@ class CkanDatasetsMapperTest {
                     .modifiedAt(OffsetDateTime.parse("2024-07-02T22:00Z"))
                     .createdAt(OffsetDateTime.parse("2024-07-01T22:00Z"))
                     .distributionsCount(1)
+                    .inSeriesCount(2)
                     .numberOfUniqueIndividuals(123456789)
                     .accessRights(getValueLabel("accessRights", "public", 10))
                     .conformsTo(

--- a/src/test/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/quarkus/DatasetSearchTest.java
+++ b/src/test/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/quarkus/DatasetSearchTest.java
@@ -32,6 +32,7 @@ class DatasetSearchTest extends BaseTest {
                 .statusCode(200)
                 .body("count", equalTo(3))
                 .body("facets.find { it.key == 'tags' }.values.size()", greaterThan(0))
+                .body("results[0].inSeriesCount", equalTo(2))
                 .body("results[0].identifier", equalTo("27866022694497975"))
                 .body("results[1].identifier", equalTo("euc_kauno_uc6"))
                 .body("results[2].identifier", equalTo("cp-tavi"));
@@ -50,6 +51,7 @@ class DatasetSearchTest extends BaseTest {
                 .statusCode(200)
                 .body("count", equalTo(3))
                 .body("facets.find { it.key == 'tags' }.values.size()", greaterThan(0))
+                .body("results[0].inSeriesCount", equalTo(2))
                 .body("results[0].identifier", equalTo("27866022694497975"))
                 .body("results[1].identifier", equalTo("euc_kauno_uc6"))
                 .body("results[2].identifier", equalTo("cp-tavi"));
@@ -100,6 +102,7 @@ class DatasetSearchTest extends BaseTest {
                 .statusCode(200)
                 .body("count", equalTo(1))
                 .body("results[0].identifier", equalTo("27866022694497975"))
+                .body("results[0].inSeriesCount", equalTo(2))
                 .body("facets.find { it.key == 'tags' }.values.size()", equalTo(1))
                 .body("facets.find { it.key == 'tags' }.values[0].value", equalTo("synthetic"));
     }
@@ -129,6 +132,7 @@ class DatasetSearchTest extends BaseTest {
                 .body("count", equalTo(1))
                 .body("results[0].identifier", equalTo("27866022694497975"))
                 .body("results[0].recordsCount", equalTo(64))
+                .body("results[0].inSeriesCount", equalTo(2))
                 .body("facets.find { it.key == 'tags' }.values.size()", equalTo(1))
                 .body("facets.find { it.source == 'beacon' && it.key == 'sex' }.label",
                         equalTo("Sex"));

--- a/src/test/resources/mappings/package_search_datasets_when_query_ckan_and_beacon.json
+++ b/src/test/resources/mappings/package_search_datasets_when_query_ckan_and_beacon.json
@@ -47,6 +47,12 @@
                         "metadata_modified": "2024-03-19T13:37:10.885817",
                         "name": "brain_mri_wml_vumcadc3",
                         "notes": "This collection will include brain MRI scans on which the amount of white matter lesions (WML) will be quantified. ",
+                        "in_series": [
+                            "series-a",
+                            "series-b",
+                            "series-a",
+                            " "
+                        ],
                         "num_resources": 0,
                         "num_tags": 0,
                         "organization": {

--- a/src/test/resources/mappings/package_search_datasets_when_query_ckan_only.json
+++ b/src/test/resources/mappings/package_search_datasets_when_query_ckan_only.json
@@ -48,6 +48,12 @@
                         "metadata_modified": "2024-03-19T13:37:10.885817",
                         "name": "brain_mri_wml_vumcadc3",
                         "notes": "This collection will include brain MRI scans on which the amount of white matter lesions (WML) will be quantified. ",
+                        "in_series": [
+                            "series-a",
+                            "series-b",
+                            "series-a",
+                            " "
+                        ],
                         "num_resources": 0,
                         "num_tags": 0,
                         "organization": {
@@ -118,6 +124,9 @@
                         "metadata_modified": "2024-03-19T13:37:08.812120",
                         "name": "eucanimage_kauno_uc61",
                         "notes": "Within the EuCanImage project (https://eucanimage.eu/), imaging datasets are collected from multiple sites to facilitate the use of AI for cancer research. The BMIA XNAT will be used as main image data storage platform for centralized storage. As first usecase, breast cancer was identified, for which the first datasets will be collected from the University of Barcelona. The data will first be available to partners within the consortium, but will potentially be publicly released",
+                        "in_series": [
+                            "series-c"
+                        ],
                         "num_resources": 0,
                         "num_tags": 0,
                         "organization": {

--- a/src/test/resources/mappings/package_search_datasets_with_ckan_filter.json
+++ b/src/test/resources/mappings/package_search_datasets_with_ckan_filter.json
@@ -48,6 +48,12 @@
             "metadata_modified": "2024-03-19T13:37:10.885817",
             "name": "brain_mri_wml_vumcadc3",
             "notes": "This collection will include brain MRI scans on which the amount of white matter lesions (WML) will be quantified. ",
+            "in_series": [
+              "series-a",
+              "series-b",
+              "series-a",
+              " "
+            ],
             "num_resources": 0,
             "num_tags": 0,
             "organization": {


### PR DESCRIPTION
- Introduced a new mapping for inSeriesCount in CkanDatasetsMapper to count unique dataset series references.
- Updated OpenAPI specification to include inSeriesCount.
- Enhanced tests to validate inSeriesCount functionality across various scenarios.
- Modified JSON mappings to include in_series data for datasets.

<!-- SPDX-FileCopyrightText: 2024 PNED G.I.E. -->

<!-- SPDX-License-Identifier: Apache-2.0 -->

## 🚀 Pull Request Checklist

- **Title:**

  - `[ ]` A brief, descriptive title for the changes.

- **Description:**

  - `[ ]` Provide a clear and concise description of your pull request, including the purpose of the changes and the approach you've taken.

- **Context:**

  - `[ ]` Why are these changes necessary? What problem do they solve? Link any related issues.

- **Changes:**

  - `[ ]` List the major changes you've made, ideally organized by commit or feature.

- **Testing:**

  - `[ ]` Describe how the changes have been tested. Include any relevant details about the testing environment and the test cases.

- **Screenshots (if applicable):**

  - `[ ]` If your changes are visual, include screenshots to help explain your changes.

- **Additional Information:**

  - `[ ]` Add any other information that might be useful for reviewers, such as considerations, discussions, or dependencies.

- **Checklist:**
  - `[ ]` I have checked that my code adheres to the project's style guidelines and that my code is well-commented.
  - `[ ]` I have performed self-review of my own code and corrected any misspellings.
  - `[ ]` I have made corresponding changes to the documentation (if applicable).
  - `[ ]` My changes generate no new warnings or errors.
  - `[ ]` I have added tests that prove my fix is effective or that my feature works.
  - `[ ]` New and existing unit tests pass locally with my changes.

## Summary by Sourcery

Add support for exposing the number of unique dataset series for each CKAN dataset in search results.

New Features:
- Populate a new inSeriesCount field on SearchedDataset based on unique non-empty inSeries values from CKAN packages.
- Expose inSeriesCount in the discovery API schema for dataset search responses.

Tests:
- Extend mapper and dataset search integration tests to cover inSeriesCount calculation and API output.