### PR TITLE
feat: add temporal coverage start and end mappings to CkanDatasetsMapper, update OpenAPI schema, and enhance tests

### DIFF
--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/mapper/CkanDatasetsMapper.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/mapper/CkanDatasetsMapper.java
@@ -171,6 +171,8 @@ public interface CkanDatasetsMapper {
     @Mapping(target = "conformsTo", source = "conformsTo")
     @Mapping(target = "numberOfUniqueIndividuals", source = "numberOfUniqueIndividuals")
     @Mapping(target = "temporalCoverage", source = "temporalCoverage")
+    @Mapping(target = "temporalCoverageStart", source = "temporalCoverage", qualifiedByName = "mapEarliestTemporalCoverageStart")
+    @Mapping(target = "temporalCoverageEnd", source = "temporalCoverage", qualifiedByName = "mapLatestTemporalCoverageEnd")
     @Mapping(target = "distributionsCount", source = ".", qualifiedByName = "countDistributions")
     @Mapping(target = "inSeriesCount", source = ".", qualifiedByName = "countInSeries")
     @Mapping(target = "isSeries", source = ".", qualifiedByName = "isDatasetSeries")
@@ -192,6 +194,40 @@ public interface CkanDatasetsMapper {
     @Mapping(target = "start", source = "start")
     @Mapping(target = "end", source = "end")
     TimeWindow map(CkanTimeWindow timeWindow);
+
+    @Named("mapEarliestTemporalCoverageStart")
+    default OffsetDateTime mapEarliestTemporalCoverageStart(
+            List<CkanTimeWindow> temporalCoverage) {
+        if (temporalCoverage == null || temporalCoverage.isEmpty()) {
+            return null;
+        }
+
+        return temporalCoverage.stream()
+                .filter(Objects::nonNull)
+                .map(CkanTimeWindow::getStart)
+                .filter(StringUtils::isNotBlank)
+                .map(this::map)
+                .filter(Objects::nonNull)
+                .min(OffsetDateTime::compareTo)
+                .orElse(null);
+    }
+
+    @Named("mapLatestTemporalCoverageEnd")
+    default OffsetDateTime mapLatestTemporalCoverageEnd(
+            List<CkanTimeWindow> temporalCoverage) {
+        if (temporalCoverage == null || temporalCoverage.isEmpty()) {
+            return null;
+        }
+
+        return temporalCoverage.stream()
+                .filter(Objects::nonNull)
+                .map(CkanTimeWindow::getEnd)
+                .filter(StringUtils::isNotBlank)
+                .map(this::map)
+                .filter(Objects::nonNull)
+                .max(OffsetDateTime::compareTo)
+                .orElse(null);
+    }
 
     @Mapping(target = "uri", source = "uri")
     @Mapping(target = "text", source = "text")

--- a/src/main/openapi/discovery.yaml
+++ b/src/main/openapi/discovery.yaml
@@ -386,6 +386,14 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/TimeWindow"
+        temporalCoverageStart:
+          type: string
+          format: date-time
+          description: Earliest available temporal coverage start across all periods.
+        temporalCoverageEnd:
+          type: string
+          format: date-time
+          description: Latest available temporal coverage end across all periods.
         recordsCount:
           type: integer
           title: Records count

--- a/src/test/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/mapper/CkanDatasetsMapperTest.java
+++ b/src/test/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/mapper/CkanDatasetsMapperTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.time.OffsetDateTime;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -675,6 +676,59 @@ class CkanDatasetsMapperTest {
                     .isEqualTo(parse("2018-05-01T00:00:00Z"));
             assertThat(actual.getTemporalCoverageEnd())
                     .isEqualTo(parse("2024-02-01T00:00:00Z"));
+        }
+
+        @Test
+        void given_null_temporal_coverage_should_map_null_summary_fields() {
+            final var ckanPackage = CkanPackage.builder()
+                    .id("dataset-id")
+                    .title("Dataset title")
+                    .notes("Dataset description")
+                    .type(getCkanValueLabel("dataset", "dataset"))
+                    .temporalCoverage(null)
+                    .build();
+
+            final var actual = mapper.mapToSearchedDataset(ckanPackage);
+
+            assertThat(actual.getTemporalCoverageStart()).isNull();
+            assertThat(actual.getTemporalCoverageEnd()).isNull();
+        }
+
+        @Test
+        void given_empty_temporal_coverage_should_map_null_summary_fields() {
+            final var ckanPackage = CkanPackage.builder()
+                    .id("dataset-id")
+                    .title("Dataset title")
+                    .notes("Dataset description")
+                    .type(getCkanValueLabel("dataset", "dataset"))
+                    .temporalCoverage(List.of())
+                    .build();
+
+            final var actual = mapper.mapToSearchedDataset(ckanPackage);
+
+            assertThat(actual.getTemporalCoverageStart()).isNull();
+            assertThat(actual.getTemporalCoverageEnd()).isNull();
+        }
+
+        @Test
+        void given_temporal_coverage_without_valid_start_or_end_should_map_null_summary_fields() {
+            final var temporalCoverage = new ArrayList<CkanTimeWindow>();
+            temporalCoverage.add(null);
+            temporalCoverage.add(CkanTimeWindow.builder().start(" ").end(" ").build());
+            temporalCoverage.add(CkanTimeWindow.builder().start(null).end(null).build());
+
+            final var ckanPackage = CkanPackage.builder()
+                    .id("dataset-id")
+                    .title("Dataset title")
+                    .notes("Dataset description")
+                    .type(getCkanValueLabel("dataset", "dataset"))
+                    .temporalCoverage(temporalCoverage)
+                    .build();
+
+            final var actual = mapper.mapToSearchedDataset(ckanPackage);
+
+            assertThat(actual.getTemporalCoverageStart()).isNull();
+            assertThat(actual.getTemporalCoverageEnd()).isNull();
         }
 
         @NotNull

--- a/src/test/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/mapper/CkanDatasetsMapperTest.java
+++ b/src/test/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/mapper/CkanDatasetsMapperTest.java
@@ -649,6 +649,34 @@ class CkanDatasetsMapperTest {
                     .isEqualTo(expected);
         }
 
+        @Test
+        void given_split_temporal_coverage_should_map_summary_start_and_end_on_search_result() {
+            final var ckanPackage = CkanPackage.builder()
+                    .id("dataset-id")
+                    .title("Dataset title")
+                    .notes("Dataset description")
+                    .type(getCkanValueLabel("dataset", "dataset"))
+                    .temporalCoverage(List.of(
+                            CkanTimeWindow.builder()
+                                    .start("2021-03-01T00:00:00+00:00")
+                                    .end("2021-12-31T00:00:00+00:00")
+                                    .build(),
+                            CkanTimeWindow.builder()
+                                    .start("2018-05-01T00:00:00+00:00")
+                                    .build(),
+                            CkanTimeWindow.builder()
+                                    .end("2024-02-01T00:00:00+00:00")
+                                    .build()))
+                    .build();
+
+            final var actual = mapper.mapToSearchedDataset(ckanPackage);
+
+            assertThat(actual.getTemporalCoverageStart())
+                    .isEqualTo(parse("2018-05-01T00:00:00Z"));
+            assertThat(actual.getTemporalCoverageEnd())
+                    .isEqualTo(parse("2024-02-01T00:00:00Z"));
+        }
+
         @NotNull
         private static SearchedDataset buildSearchedDataset() {
             return SearchedDataset.builder()
@@ -693,6 +721,8 @@ class CkanDatasetsMapperTest {
                                     .start(parse("2024-07-12T22:00Z"))
                                     .end(parse("2024-07-13T22:00Z"))
                                     .build()))
+                    .temporalCoverageStart(parse("2024-07-12T22:00Z"))
+                    .temporalCoverageEnd(parse("2024-07-13T22:00Z"))
                     .build();
         }
     }


### PR DESCRIPTION
- Introduced mappings for `temporalCoverageStart` and `temporalCoverageEnd` in `CkanDatasetsMapper` to capture the earliest and latest temporal coverage.
- Updated OpenAPI specifications to include new fields for temporal coverage.
- Enhanced unit tests to validate the mapping of temporal coverage start and end values from multiple time windows.

<!-- SPDX-FileCopyrightText: 2024 PNED G.I.E. -->

<!-- SPDX-License-Identifier: Apache-2.0 -->

## 🚀 Pull Request Checklist

- **Title:**

  - `[ ]` A brief, descriptive title for the changes.

- **Description:**

  - `[ ]` Provide a clear and concise description of your pull request, including the purpose of the changes and the approach you've taken.

- **Context:**

  - `[ ]` Why are these changes necessary? What problem do they solve? Link any related issues.

- **Changes:**

  - `[ ]` List the major changes you've made, ideally organized by commit or feature.

- **Testing:**

  - `[ ]` Describe how the changes have been tested. Include any relevant details about the testing environment and the test cases.

- **Screenshots (if applicable):**

  - `[ ]` If your changes are visual, include screenshots to help explain your changes.

- **Additional Information:**

  - `[ ]` Add any other information that might be useful for reviewers, such as considerations, discussions, or dependencies.

- **Checklist:**
  - `[ ]` I have checked that my code adheres to the project's style guidelines and that my code is well-commented.
  - `[ ]` I have performed self-review of my own code and corrected any misspellings.
  - `[ ]` I have made corresponding changes to the documentation (if applicable).
  - `[ ]` My changes generate no new warnings or errors.
  - `[ ]` I have added tests that prove my fix is effective or that my feature works.
  - `[ ]` New and existing unit tests pass locally with my changes.

## Summary by Sourcery

Add summary temporal coverage start and end fields to dataset search results and expose them via the API schema.

New Features:
- Introduce mapping of earliest temporalCoverageStart and latest temporalCoverageEnd from CKAN temporal windows into SearchedDataset.
- Expose temporalCoverageStart and temporalCoverageEnd properties in the discovery OpenAPI schema for dataset search responses.

Tests:
- Add unit coverage to verify temporalCoverageStart and temporalCoverageEnd are derived correctly from multiple temporal windows.
- Extend existing SearchedDataset test fixtures to include expected temporalCoverageStart and temporalCoverageEnd values.