### PR TITLE
feat: enhance temporal coverage handling in CkanDatasetsMapper

### DIFF
--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/config/JacksonConfig.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/config/JacksonConfig.java
@@ -31,6 +31,11 @@ public class JacksonConfig implements ObjectMapperCustomizer {
         // (e.g. contact.url as "https://..." instead of ["https://..."])
         objectMapper.enable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY);
 
+        // For Collection types, coerce empty objects {} to empty lists
+        // This handles cases where CKAN returns {} for array fields like temporal_coverage
+        objectMapper.coercionConfigFor(LogicalType.Collection)
+                .setCoercion(CoercionInputShape.EmptyObject, CoercionAction.AsEmpty);
+
         // For POJO types, coerce empty strings to null
         // This handles cases where CKAN returns "" instead of {} or null
         objectMapper.coercionConfigFor(LogicalType.POJO)

--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/mapper/CkanDatasetsMapper.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/mapper/CkanDatasetsMapper.java
@@ -186,7 +186,7 @@ public interface CkanDatasetsMapper {
         }
 
         return temporalCoverage.stream()
-                .filter(Objects::nonNull)
+                .filter(this::hasTemporalCoverageValue)
                 .map(this::map)
                 .toList();
     }
@@ -194,6 +194,15 @@ public interface CkanDatasetsMapper {
     @Mapping(target = "start", source = "start")
     @Mapping(target = "end", source = "end")
     TimeWindow map(CkanTimeWindow timeWindow);
+
+    default boolean hasTemporalCoverageValue(CkanTimeWindow timeWindow) {
+        if (timeWindow == null) {
+            return false;
+        }
+
+        return StringUtils.isNotBlank(timeWindow.getStart())
+                || StringUtils.isNotBlank(timeWindow.getEnd());
+    }
 
     @Named("mapEarliestTemporalCoverageStart")
     default OffsetDateTime mapEarliestTemporalCoverageStart(

--- a/src/test/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/mapper/CkanDatasetsMapperTest.java
+++ b/src/test/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/mapper/CkanDatasetsMapperTest.java
@@ -690,6 +690,7 @@ class CkanDatasetsMapperTest {
 
             final var actual = mapper.mapToSearchedDataset(ckanPackage);
 
+            assertThat(actual.getTemporalCoverage()).isEmpty();
             assertThat(actual.getTemporalCoverageStart()).isNull();
             assertThat(actual.getTemporalCoverageEnd()).isNull();
         }


### PR DESCRIPTION
- Added a method to filter out temporal coverage values that are null or blank.
- Updated the mapping logic to ensure only valid temporal coverage values are processed.
- Enhanced unit tests to verify the correct handling of empty temporal coverage scenarios.

<!-- SPDX-FileCopyrightText: 2024 PNED G.I.E. -->

<!-- SPDX-License-Identifier: Apache-2.0 -->

## 🚀 Pull Request Checklist

- **Title:**

  - `[ ]` A brief, descriptive title for the changes.

- **Description:**

  - `[ ]` Provide a clear and concise description of your pull request, including the purpose of the changes and the approach you've taken.

- **Context:**

  - `[ ]` Why are these changes necessary? What problem do they solve? Link any related issues.

- **Changes:**

  - `[ ]` List the major changes you've made, ideally organized by commit or feature.

- **Testing:**

  - `[ ]` Describe how the changes have been tested. Include any relevant details about the testing environment and the test cases.

- **Screenshots (if applicable):**

  - `[ ]` If your changes are visual, include screenshots to help explain your changes.

- **Additional Information:**

  - `[ ]` Add any other information that might be useful for reviewers, such as considerations, discussions, or dependencies.

- **Checklist:**
  - `[ ]` I have checked that my code adheres to the project's style guidelines and that my code is well-commented.
  - `[ ]` I have performed self-review of my own code and corrected any misspellings.
  - `[ ]` I have made corresponding changes to the documentation (if applicable).
  - `[ ]` My changes generate no new warnings or errors.
  - `[ ]` I have added tests that prove my fix is effective or that my feature works.
  - `[ ]` New and existing unit tests pass locally with my changes.

## Summary by Sourcery

Improve handling of CKAN temporal coverage data to ignore empty values and better align deserialization with CKAN responses.

Enhancements:
- Filter temporal coverage entries to only process time windows with non-blank start or end values.
- Configure Jackson to coerce empty JSON objects into empty collections for CKAN collection fields such as temporal_coverage.

Tests:
- Extend temporal coverage mapper tests to assert empty temporal coverage lists when CKAN returns null or empty structures.