### PR TITLE
feat: update OpenAPI schema to allow nullable fields for description and ID

### DIFF
--- a/src/main/openapi/discovery.yaml
+++ b/src/main/openapi/discovery.yaml
@@ -831,6 +831,7 @@ components:
                   type: string
               description:
                 type: string
+                nullable: true
               endpointDescription:
                 type: string
               endpoint_url:
@@ -844,6 +845,7 @@ components:
               id:
                 type: string
                 title: Data service internal ID
+                nullable: true
               keywords:
                 type: array
                 items:


### PR DESCRIPTION
- Modified the OpenAPI schema to set the `description` and `id` fields as nullable, enhancing flexibility in data representation.

<!-- SPDX-FileCopyrightText: 2024 PNED G.I.E. -->

<!-- SPDX-License-Identifier: Apache-2.0 -->

## 🚀 Pull Request Checklist

- **Title:**

  - `[ ]` A brief, descriptive title for the changes.

- **Description:**

  - `[ ]` Provide a clear and concise description of your pull request, including the purpose of the changes and the approach you've taken.

- **Context:**

  - `[ ]` Why are these changes necessary? What problem do they solve? Link any related issues.

- **Changes:**

  - `[ ]` List the major changes you've made, ideally organized by commit or feature.

- **Testing:**

  - `[ ]` Describe how the changes have been tested. Include any relevant details about the testing environment and the test cases.

- **Screenshots (if applicable):**

  - `[ ]` If your changes are visual, include screenshots to help explain your changes.

- **Additional Information:**

  - `[ ]` Add any other information that might be useful for reviewers, such as considerations, discussions, or dependencies.

- **Checklist:**
  - `[ ]` I have checked that my code adheres to the project's style guidelines and that my code is well-commented.
  - `[ ]` I have performed self-review of my own code and corrected any misspellings.
  - `[ ]` I have made corresponding changes to the documentation (if applicable).
  - `[ ]` My changes generate no new warnings or errors.
  - `[ ]` I have added tests that prove my fix is effective or that my feature works.
  - `[ ]` New and existing unit tests pass locally with my changes.

## Summary by Sourcery

Allow null values for selected fields in the discovery OpenAPI schema

Enhancements:
- Mark the data service description field in the discovery OpenAPI schema as nullable to support missing descriptions
- Mark the data service internal ID field in the discovery OpenAPI schema as nullable to allow resources without an ID value