### PR TITLE
feat: enhance date handling in CkanFacetsQueryBuilder

### DIFF
--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/persistence/CkanFacetsQueryBuilder.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/persistence/CkanFacetsQueryBuilder.java
@@ -11,6 +11,10 @@ import io.github.genomicdatainfrastructure.discovery.model.FilterType;
 import io.github.genomicdatainfrastructure.discovery.model.Operator;
 import lombok.experimental.UtilityClass;
 
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeParseException;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -27,6 +31,7 @@ public class CkanFacetsQueryBuilder {
     private static final String QUOTED_VALUE = "\"%s\"";
     private static final String FACET_PATTERN = "%s:(%s)";
     private static final String RANGE_PATTERN = "%s:[%s TO %s]";
+    private static final String RANGE_WITH_BOUNDARIES_PATTERN = "%s:%s%s TO %s%s";
     private static final String RANGE_WILDCARD = "*";
     private static final String AND = " AND ";
     private static final String TYPICAL_AGE_KEY = "typical_age";
@@ -102,13 +107,17 @@ public class CkanFacetsQueryBuilder {
             return Optional.empty();
         }
 
-        var lower = findValueByOperator(dateTimeFacets,
+        var lower = findFacetByOperator(dateTimeFacets,
                 Operator.GREATER_THAN_OR_EQUAL_TO_SYMBOL,
-                Operator.GREATER_THAN_SYMBOL).orElse(null);
+                Operator.GREATER_THAN_SYMBOL)
+                .map(CkanFacetsQueryBuilder::toLowerDateTimeBound)
+                .orElse(null);
 
-        var upper = findValueByOperator(dateTimeFacets,
+        var upper = findFacetByOperator(dateTimeFacets,
                 Operator.LESS_THAN_OR_EQUAL_TO_SYMBOL,
-                Operator.LESS_THAN_SYMBOL).orElse(null);
+                Operator.LESS_THAN_SYMBOL)
+                .map(CkanFacetsQueryBuilder::toUpperDateTimeBound)
+                .orElse(null);
 
         var exact = findValueByOperator(dateTimeFacets, Operator.EQUAL_SYMBOL).orElse(null);
 
@@ -223,13 +232,86 @@ public class CkanFacetsQueryBuilder {
                 .findFirst();
     }
 
+    private Optional<DatasetSearchQueryFacet> findFacetByOperator(
+            List<DatasetSearchQueryFacet> facets, Operator... operators
+    ) {
+        if (operators == null || operators.length == 0) {
+            return Optional.empty();
+        }
+
+        var allowedOperators = EnumSet.noneOf(Operator.class);
+        allowedOperators.addAll(List.of(operators));
+
+        return facets.stream()
+                .filter(facet -> facet.getOperator() != null &&
+                        allowedOperators.contains(facet.getOperator()))
+                .filter(facet -> facet.getValue() != null && !facet.getValue().isBlank())
+                .findFirst();
+    }
+
+    private DateTimeBound toLowerDateTimeBound(DatasetSearchQueryFacet facet) {
+        var normalizedValue = facet.getValue().trim();
+        var parsedDateOnly = parseDateOnlyRange(normalizedValue).orElse(null);
+
+        if (Operator.GREATER_THAN_SYMBOL.equals(facet.getOperator())) {
+            if (parsedDateOnly != null) {
+                return new DateTimeBound(parsedDateOnly.endExclusive(), true);
+            }
+            return new DateTimeBound(normalizedValue, false);
+        }
+
+        if (parsedDateOnly != null) {
+            return new DateTimeBound(parsedDateOnly.start(), true);
+        }
+        return new DateTimeBound(normalizedValue, true);
+    }
+
+    private DateTimeBound toUpperDateTimeBound(DatasetSearchQueryFacet facet) {
+        var normalizedValue = facet.getValue().trim();
+        var parsedDateOnly = parseDateOnlyRange(normalizedValue).orElse(null);
+
+        if (Operator.LESS_THAN_SYMBOL.equals(facet.getOperator())) {
+            if (parsedDateOnly != null) {
+                return new DateTimeBound(parsedDateOnly.start(), false);
+            }
+            return new DateTimeBound(normalizedValue, false);
+        }
+
+        if (parsedDateOnly != null) {
+            return new DateTimeBound(parsedDateOnly.endExclusive(), false);
+        }
+        return new DateTimeBound(normalizedValue, true);
+    }
+
+    private Optional<DateOnlyRange> parseDateOnlyRange(String value) {
+        if (value == null || value.isBlank()) {
+            return Optional.empty();
+        }
+
+        try {
+            var date = LocalDate.parse(value);
+            var start = date.atStartOfDay(ZoneOffset.UTC).toInstant().toString();
+            var endExclusive = date.plusDays(1)
+                    .atStartOfDay(ZoneOffset.UTC)
+                    .toInstant()
+                    .toString();
+            return Optional.of(new DateOnlyRange(start, endExclusive));
+        } catch (DateTimeParseException exception) {
+            return Optional.empty();
+        }
+    }
+
     private static String formatRangeBoundary(String value) {
         return value == null || value.isBlank()
                 ? RANGE_WILDCARD
                 : QUOTED_VALUE.formatted(value);
     }
 
-    private record DateTimeCondition(String lowerBound, String upperBound, String exactMatch) {
+    private record DateTimeCondition(
+                                     DateTimeBound lowerBound,
+                                     DateTimeBound upperBound,
+                                     String exactMatch
+    ) {
 
         private boolean hasRange() {
             return lowerBound != null || upperBound != null;
@@ -241,18 +323,49 @@ public class CkanFacetsQueryBuilder {
 
         private Optional<String> toSolrQuery(String key) {
             if (hasRange()) {
-                var start = formatRangeBoundary(lowerBound);
-                var end = formatRangeBoundary(upperBound);
-                return Optional.of(RANGE_PATTERN.formatted(key, start, end));
+                var startBoundary = lowerBound != null && !lowerBound.inclusive() ? "{" : "[";
+                var endBoundary = upperBound != null && !upperBound.inclusive() ? "}" : "]";
+                var start = lowerBound != null
+                        ? QUOTED_VALUE.formatted(lowerBound.value())
+                        : RANGE_WILDCARD;
+                var end = upperBound != null
+                        ? QUOTED_VALUE.formatted(upperBound.value())
+                        : RANGE_WILDCARD;
+                return Optional.of(RANGE_WITH_BOUNDARIES_PATTERN.formatted(
+                        key,
+                        startBoundary,
+                        start,
+                        end,
+                        endBoundary
+                ));
             }
 
             if (hasExactMatch()) {
+                var dayRange = parseDateOnlyRange(exactMatch);
+                if (dayRange.isPresent()) {
+                    var parsedDayRange = dayRange.orElseThrow();
+                    var start = QUOTED_VALUE.formatted(parsedDayRange.start());
+                    var endExclusive = QUOTED_VALUE.formatted(parsedDayRange.endExclusive());
+                    return Optional.of(RANGE_WITH_BOUNDARIES_PATTERN.formatted(
+                            key,
+                            "[",
+                            start,
+                            endExclusive,
+                            "}"
+                    ));
+                }
                 var value = QUOTED_VALUE.formatted(exactMatch);
                 return Optional.of(FACET_PATTERN.formatted(key, value));
             }
 
             return Optional.empty();
         }
+    }
+
+    private record DateOnlyRange(String start, String endExclusive) {
+    }
+
+    private record DateTimeBound(String value, boolean inclusive) {
     }
 
     private static String formatNumberBoundary(String value) {

--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/filters/infrastructure/ckan/CkanSearchFacetsMapper.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/filters/infrastructure/ckan/CkanSearchFacetsMapper.java
@@ -8,6 +8,7 @@ import io.github.genomicdatainfrastructure.discovery.filters.infrastructure.quar
 import io.github.genomicdatainfrastructure.discovery.model.Filter;
 import io.github.genomicdatainfrastructure.discovery.model.FilterRange;
 import io.github.genomicdatainfrastructure.discovery.model.FilterType;
+import io.github.genomicdatainfrastructure.discovery.model.Operator;
 import io.github.genomicdatainfrastructure.discovery.model.ValueLabel;
 import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.CkanFacet;
 import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.CkanValueLabel;
@@ -37,6 +38,13 @@ public class CkanSearchFacetsMapper {
 
     private static final String SELECTED_FACETS_PATTERN = "[\"%s\"]";
     private static final FilterType DEFAULT_FILTER_TYPE = FilterType.DROPDOWN;
+    private static final List<Operator> RANGE_OPERATORS = List.of(
+            Operator.EQUAL_SYMBOL,
+            Operator.GREATER_THAN_SYMBOL,
+            Operator.LESS_THAN_SYMBOL,
+            Operator.GREATER_THAN_OR_EQUAL_TO_SYMBOL,
+            Operator.LESS_THAN_OR_EQUAL_TO_SYMBOL
+    );
 
     private final String selectedFacets;
     private final Map<String, FilterMetadata> filtersMetadata;
@@ -169,6 +177,7 @@ public class CkanSearchFacetsMapper {
                 .key(key)
                 .label(label)
                 .range(extractDateTimeRange(facet))
+                .operators(RANGE_OPERATORS)
                 .group(group)
                 .build();
     }
@@ -181,6 +190,7 @@ public class CkanSearchFacetsMapper {
                 .key(key)
                 .label(label)
                 .range(extractNumberRange(facet))
+                .operators(RANGE_OPERATORS)
                 .group(group)
                 .build();
     }

--- a/src/main/openapi/discovery.yaml
+++ b/src/main/openapi/discovery.yaml
@@ -1038,6 +1038,12 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/Operator"
+          default:
+            - "="
+            - ">"
+            - "<"
+            - ">="
+            - "<="
         entries:
           type: array
           items:

--- a/src/test/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/CkanFacetsQueryBuilderTest.java
+++ b/src/test/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/CkanFacetsQueryBuilderTest.java
@@ -230,6 +230,86 @@ class CkanFacetsQueryBuilderTest {
     }
 
     @Test
+    void canParse_withDateExactFacetDateOnly() {
+        var query = DatasetSearchQuery.builder()
+                .facets(List.of(
+                        DatasetSearchQueryFacet.builder()
+                                .source("ckan")
+                                .type(FilterType.DATETIME)
+                                .key("metadata_modified")
+                                .operator(Operator.EQUAL_SYMBOL)
+                                .value("2024-11-01")
+                                .build()
+                ))
+                .build();
+
+        var expected = "metadata_modified:[\"2024-11-01T00:00:00Z\" TO \"2024-11-02T00:00:00Z\"}";
+        var actual = CkanFacetsQueryBuilder.buildFacetQuery(query);
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void canParse_withDateGreaterThanFacetDateOnly() {
+        var query = DatasetSearchQuery.builder()
+                .facets(List.of(
+                        DatasetSearchQueryFacet.builder()
+                                .source("ckan")
+                                .type(FilterType.DATETIME)
+                                .key("metadata_modified")
+                                .operator(Operator.GREATER_THAN_SYMBOL)
+                                .value("2024-11-01")
+                                .build()
+                ))
+                .build();
+
+        var expected = "metadata_modified:[\"2024-11-02T00:00:00Z\" TO *]";
+        var actual = CkanFacetsQueryBuilder.buildFacetQuery(query);
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void canParse_withDateGreaterThanOrEqualFacetDateOnly() {
+        var query = DatasetSearchQuery.builder()
+                .facets(List.of(
+                        DatasetSearchQueryFacet.builder()
+                                .source("ckan")
+                                .type(FilterType.DATETIME)
+                                .key("metadata_modified")
+                                .operator(Operator.GREATER_THAN_OR_EQUAL_TO_SYMBOL)
+                                .value("2024-11-01")
+                                .build()
+                ))
+                .build();
+
+        var expected = "metadata_modified:[\"2024-11-01T00:00:00Z\" TO *]";
+        var actual = CkanFacetsQueryBuilder.buildFacetQuery(query);
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void canParse_withDateExactFacetDateTime() {
+        var query = DatasetSearchQuery.builder()
+                .facets(List.of(
+                        DatasetSearchQueryFacet.builder()
+                                .source("ckan")
+                                .type(FilterType.DATETIME)
+                                .key("metadata_modified")
+                                .operator(Operator.EQUAL_SYMBOL)
+                                .value("2024-11-01T09:30:00Z")
+                                .build()
+                ))
+                .build();
+
+        var expected = "metadata_modified:(\"2024-11-01T09:30:00Z\")";
+        var actual = CkanFacetsQueryBuilder.buildFacetQuery(query);
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
     void canParse_withConfigurableDateRangeFacetKey() {
         var query = DatasetSearchQuery.builder()
                 .facets(List.of(

--- a/src/test/java/io/github/genomicdatainfrastructure/discovery/filters/infrastructure/ckan/CkanFilterBuilderTest.java
+++ b/src/test/java/io/github/genomicdatainfrastructure/discovery/filters/infrastructure/ckan/CkanFilterBuilderTest.java
@@ -83,12 +83,16 @@ class CkanFilterBuilderTest {
         assertThat(modified.getRange()).isNotNull();
         assertThat(modified.getRange().getMin()).isEqualTo("2024-01-01T00:00Z");
         assertThat(modified.getRange().getMax()).isEqualTo("2024-12-31T23:59:59Z");
+        assertThat(modified.getOperators())
+                .containsExactly("=", ">", "<", ">=", "<=");
 
         var number = findFilter(filters, "number_of_records");
         assertThat(number.getType()).isEqualTo(FilterType.NUMBER);
         assertThat(number.getRange()).isNotNull();
         assertThat(number.getRange().getMin()).isEqualTo("10");
         assertThat(number.getRange().getMax()).isEqualTo("250");
+        assertThat(number.getOperators())
+                .containsExactly("=", ">", "<", ">=", "<=");
 
         var tags = findFilter(filters, "tags");
         assertThat(tags.getValues())

--- a/src/test/java/io/github/genomicdatainfrastructure/discovery/filters/infrastructure/ckan/CkanFilterBuilderTest.java
+++ b/src/test/java/io/github/genomicdatainfrastructure/discovery/filters/infrastructure/ckan/CkanFilterBuilderTest.java
@@ -9,6 +9,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.github.genomicdatainfrastructure.discovery.filters.infrastructure.quarkus.DatasetsConfig;
 import io.github.genomicdatainfrastructure.discovery.model.Filter;
 import io.github.genomicdatainfrastructure.discovery.model.FilterType;
+import io.github.genomicdatainfrastructure.discovery.model.Operator;
 import io.github.genomicdatainfrastructure.discovery.model.ValueLabel;
 import io.github.genomicdatainfrastructure.discovery.remote.ckan.api.CkanQueryApi;
 import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.CkanFacet;
@@ -84,7 +85,13 @@ class CkanFilterBuilderTest {
         assertThat(modified.getRange().getMin()).isEqualTo("2024-01-01T00:00Z");
         assertThat(modified.getRange().getMax()).isEqualTo("2024-12-31T23:59:59Z");
         assertThat(modified.getOperators())
-                .containsExactly("=", ">", "<", ">=", "<=");
+                .containsExactly(
+                        Operator.EQUAL_SYMBOL,
+                        Operator.GREATER_THAN_SYMBOL,
+                        Operator.LESS_THAN_SYMBOL,
+                        Operator.GREATER_THAN_OR_EQUAL_TO_SYMBOL,
+                        Operator.LESS_THAN_OR_EQUAL_TO_SYMBOL
+                );
 
         var number = findFilter(filters, "number_of_records");
         assertThat(number.getType()).isEqualTo(FilterType.NUMBER);
@@ -92,7 +99,13 @@ class CkanFilterBuilderTest {
         assertThat(number.getRange().getMin()).isEqualTo("10");
         assertThat(number.getRange().getMax()).isEqualTo("250");
         assertThat(number.getOperators())
-                .containsExactly("=", ">", "<", ">=", "<=");
+                .containsExactly(
+                        Operator.EQUAL_SYMBOL,
+                        Operator.GREATER_THAN_SYMBOL,
+                        Operator.LESS_THAN_SYMBOL,
+                        Operator.GREATER_THAN_OR_EQUAL_TO_SYMBOL,
+                        Operator.LESS_THAN_OR_EQUAL_TO_SYMBOL
+                );
 
         var tags = findFilter(filters, "tags");
         assertThat(tags.getValues())

--- a/src/test/java/io/github/genomicdatainfrastructure/discovery/filters/infrastructure/quarkus/RetrieveFiltersTest.java
+++ b/src/test/java/io/github/genomicdatainfrastructure/discovery/filters/infrastructure/quarkus/RetrieveFiltersTest.java
@@ -43,11 +43,15 @@ public class RetrieveFiltersTest extends BaseTest {
                 .body("find { it.key == 'modified' }.group", equalTo("DEFAULT"))
                 .body("find { it.key == 'modified' }.range.min", equalTo("2024-01-01T00:00Z"))
                 .body("find { it.key == 'modified' }.range.max", equalTo("2024-12-31T23:59:59Z"))
+                .body("find { it.key == 'modified' }.operators", contains("=", ">", "<", ">=",
+                        "<="))
                 .body("find { it.key == 'number_of_records' }.type", equalTo("NUMBER"))
                 .body("find { it.key == 'number_of_records' }.label", equalTo("Number of records"))
                 .body("find { it.key == 'number_of_records' }.group", equalTo("DEFAULT"))
                 .body("find { it.key == 'number_of_records' }.range.min", equalTo("10"))
                 .body("find { it.key == 'number_of_records' }.range.max", equalTo("250"))
+                .body("find { it.key == 'number_of_records' }.operators",
+                        contains("=", ">", "<", ">=", "<="))
                 .body("find { it.key == 'vocab_in_series_title' }.source", equalTo("ckan"))
                 .body("find { it.key == 'vocab_in_series_title' }.type", equalTo("DROPDOWN"))
                 .body("find { it.key == 'vocab_in_series_title' }.label", equalTo("Dataset series"))


### PR DESCRIPTION
- Introduced methods to parse date-only ranges and handle date facets with greater precision.
- Updated the query builder to support inclusive and exclusive boundaries for date ranges.
- Added tests to validate the parsing of date facets for various operators, ensuring correct query generation.
- Updated OpenAPI schema to include default operators for date filters.

<!-- SPDX-FileCopyrightText: 2024 PNED G.I.E. -->

<!-- SPDX-License-Identifier: Apache-2.0 -->

## 🚀 Pull Request Checklist

- **Title:**

  - `[ ]` A brief, descriptive title for the changes.

- **Description:**

  - `[ ]` Provide a clear and concise description of your pull request, including the purpose of the changes and the approach you've taken.

- **Context:**

  - `[ ]` Why are these changes necessary? What problem do they solve? Link any related issues.

- **Changes:**

  - `[ ]` List the major changes you've made, ideally organized by commit or feature.

- **Testing:**

  - `[ ]` Describe how the changes have been tested. Include any relevant details about the testing environment and the test cases.

- **Screenshots (if applicable):**

  - `[ ]` If your changes are visual, include screenshots to help explain your changes.

- **Additional Information:**

  - `[ ]` Add any other information that might be useful for reviewers, such as considerations, discussions, or dependencies.

- **Checklist:**
  - `[ ]` I have checked that my code adheres to the project's style guidelines and that my code is well-commented.
  - `[ ]` I have performed self-review of my own code and corrected any misspellings.
  - `[ ]` I have made corresponding changes to the documentation (if applicable).
  - `[ ]` My changes generate no new warnings or errors.
  - `[ ]` I have added tests that prove my fix is effective or that my feature works.
  - `[ ]` New and existing unit tests pass locally with my changes.

## Summary by Sourcery

Improve CKAN facet query date handling and expose default range operators for datetime and numeric filters.

New Features:
- Support parsing date-only values into precise UTC datetime ranges when building CKAN facet queries.
- Allow inclusive and exclusive Solr range boundaries for datetime facets based on comparison operators.
- Expose a default set of comparison operators for datetime and number filters in the filters API response and OpenAPI schema.

Enhancements:
- Refine date facet resolution by working with structured lower/upper datetime bounds instead of raw strings.

Documentation:
- Document default operators for range-capable filters in the OpenAPI discovery schema.

Tests:
- Add unit and integration tests covering date-only and datetime facet parsing, range operator defaults, and filter operator exposure in the API.