### PR TITLE
feat: add datasetType mapping and update OpenAPI schemas

### DIFF
--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/mapper/CkanDatasetsMapper.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/mapper/CkanDatasetsMapper.java
@@ -164,6 +164,7 @@ public interface CkanDatasetsMapper {
     @Mapping(target = "description", source = "notes")
     @Mapping(target = "themes", source = "theme")
     @Mapping(target = "publishers", source = "publisher")
+    @Mapping(target = "datasetType", source = ".", qualifiedByName = "mapDatasetType")
     @Mapping(target = "keywords", source = ".", qualifiedByName = "mergeKeywords")
     @Mapping(target = "modifiedAt", source = "modified")
     @Mapping(target = "createdAt", source = "issued")
@@ -179,6 +180,29 @@ public interface CkanDatasetsMapper {
     @Mapping(target = "catalogue", ignore = true)
     @Mapping(target = "recordsCount", ignore = true)
     SearchedDataset mapToSearchedDataset(CkanPackage ckanPackage);
+
+    @Named("mapDatasetType")
+    default String mapDatasetType(CkanPackage ckanPackage) {
+        if (ckanPackage == null) {
+            return null;
+        }
+
+        if (ckanPackage.getDcatType() != null) {
+            var dcatDatasetType = Stream.of(
+                    ckanPackage.getDcatType().getDisplayName(),
+                    ckanPackage.getDcatType().getName())
+                    .map(StringUtils::trimToNull)
+                    .filter(Objects::nonNull)
+                    .findFirst()
+                    .orElse(null);
+
+            if (dcatDatasetType != null) {
+                return dcatDatasetType;
+            }
+        }
+
+        return StringUtils.trimToNull(ckanPackage.getDatasetType());
+    }
 
     default List<TimeWindow> map(List<CkanTimeWindow> temporalCoverage) {
         if (temporalCoverage == null || temporalCoverage.isEmpty()) {

--- a/src/main/openapi/ckan.yaml
+++ b/src/main/openapi/ckan.yaml
@@ -192,6 +192,8 @@ components:
           type: string
         type:
           $ref: "#/components/schemas/CkanValueLabel"
+        dataset_type:
+          type: string
         notes:
           type: string
         version:

--- a/src/main/openapi/discovery.yaml
+++ b/src/main/openapi/discovery.yaml
@@ -344,6 +344,9 @@ components:
         title:
           type: string
           title: Title
+        datasetType:
+          type: string
+          title: Dataset type
         description:
           type: string
           title: Description

--- a/src/test/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/mapper/CkanDatasetsMapperTest.java
+++ b/src/test/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/mapper/CkanDatasetsMapperTest.java
@@ -455,6 +455,7 @@ class CkanDatasetsMapperTest {
                 .version("1.0.0")
                 .licenseId("CC-BY-4.0")
                 .ownerOrg("test-organization")
+                .type(getCkanValueLabel("dataset", "dataset"))
                 .dcatType(getCkanValueLabel("type", "type-uri"))
                 .notes("notes")
                 .theme(getCkanValueLabels("theme", "theme-name", 3))
@@ -732,12 +733,43 @@ class CkanDatasetsMapperTest {
             assertThat(actual.getTemporalCoverageEnd()).isNull();
         }
 
+        @Test
+        void given_dcat_type_should_prefer_it_over_explicit_dataset_type() {
+            final var ckanPackage = CkanPackage.builder()
+                    .id("dataset-id")
+                    .title("Dataset title")
+                    .notes("Dataset description")
+                    .datasetType("externally-governed")
+                    .dcatType(getCkanValueLabel("Synthetic data",
+                            "https://publications.europa.eu/resource/authority/dataset-type/SYNTHETIC_DATA"))
+                    .build();
+
+            final var actual = mapper.mapToSearchedDataset(ckanPackage);
+
+            assertThat(actual.getDatasetType()).isEqualTo("Synthetic data");
+        }
+
+        @Test
+        void given_missing_dcat_type_should_fallback_to_explicit_dataset_type() {
+            final var ckanPackage = CkanPackage.builder()
+                    .id("dataset-id")
+                    .title("Dataset title")
+                    .notes("Dataset description")
+                    .datasetType("externally-governed")
+                    .build();
+
+            final var actual = mapper.mapToSearchedDataset(ckanPackage);
+
+            assertThat(actual.getDatasetType()).isEqualTo("externally-governed");
+        }
+
         @NotNull
         private static SearchedDataset buildSearchedDataset() {
             return SearchedDataset.builder()
                     .id("id")
                     .identifier("identifier")
                     .title("title")
+                    .datasetType("type")
                     .isSeries(false)
                     .description("notes")
                     .publishers(List.of(Agent.builder()


### PR DESCRIPTION
- Introduced a new mapping for datasetType in CkanDatasetsMapper to prioritize dcatType over explicit datasetType.
- Updated OpenAPI schemas in ckan.yaml and discovery.yaml to include dataset_type and datasetType fields.
- Added unit tests to validate the new mapping logic for datasetType in CkanDatasetsMapperTest.

<!-- SPDX-FileCopyrightText: 2024 PNED G.I.E. -->

<!-- SPDX-License-Identifier: Apache-2.0 -->

## 🚀 Pull Request Checklist

- **Title:**

  - `[ ]` A brief, descriptive title for the changes.

- **Description:**

  - `[ ]` Provide a clear and concise description of your pull request, including the purpose of the changes and the approach you've taken.

- **Context:**

  - `[ ]` Why are these changes necessary? What problem do they solve? Link any related issues.

- **Changes:**

  - `[ ]` List the major changes you've made, ideally organized by commit or feature.

- **Testing:**

  - `[ ]` Describe how the changes have been tested. Include any relevant details about the testing environment and the test cases.

- **Screenshots (if applicable):**

  - `[ ]` If your changes are visual, include screenshots to help explain your changes.

- **Additional Information:**

  - `[ ]` Add any other information that might be useful for reviewers, such as considerations, discussions, or dependencies.

- **Checklist:**
  - `[ ]` I have checked that my code adheres to the project's style guidelines and that my code is well-commented.
  - `[ ]` I have performed self-review of my own code and corrected any misspellings.
  - `[ ]` I have made corresponding changes to the documentation (if applicable).
  - `[ ]` My changes generate no new warnings or errors.
  - `[ ]` I have added tests that prove my fix is effective or that my feature works.
  - `[ ]` New and existing unit tests pass locally with my changes.

## Summary by Sourcery

Map CKAN dataset types into the search API model and expose them via the OpenAPI schemas.

New Features:
- Determine datasetType for searched datasets by preferring DCAT dataset type metadata and falling back to the explicit CKAN dataset_type field.
- Expose datasetType on the discovery API SearchedDataset schema and dataset_type on the CKAN package schema.

Tests:
- Add unit tests covering dataset type precedence between DCAT type and explicit dataset_type in CkanDatasetsMapper.