### PR TITLE
Fix zizmor: correct graalvm/setup-graalvm hash pin to match v1.5.5

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,7 +48,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up GraalVM JDK 21
-        uses: graalvm/setup-graalvm@bef4b0e916c7dd079bf60fb95d49139f67e32c5f # v1
+        uses: graalvm/setup-graalvm@bef4b0e916c7dd079bf60fb95d49139f67e32c5f # v1.5.5
         with:
           java-version: "21"
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,7 +48,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up GraalVM JDK 21
-        uses: graalvm/setup-graalvm@bef4b0e916c7dd079bf60fb95d49139f67e32c5f # v1.5.5
+        uses: graalvm/setup-graalvm@809afe62741147990fbf405045cd15e61bffedfe # v1.5.5
         with:
           java-version: "21"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,7 +134,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up GraalVM JDK 21
-        uses: graalvm/setup-graalvm@bef4b0e916c7dd079bf60fb95d49139f67e32c5f # v1
+        uses: graalvm/setup-graalvm@bef4b0e916c7dd079bf60fb95d49139f67e32c5f # v1.5.5
         with:
           java-version: "21"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,7 +134,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up GraalVM JDK 21
-        uses: graalvm/setup-graalvm@bef4b0e916c7dd079bf60fb95d49139f67e32c5f # v1.5.5
+        uses: graalvm/setup-graalvm@809afe62741147990fbf405045cd15e61bffedfe # v1.5.5
         with:
           java-version: "21"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Set up GraalVM JDK 21
-        uses: graalvm/setup-graalvm@bef4b0e916c7dd079bf60fb95d49139f67e32c5f # v1.5.5
+        uses: graalvm/setup-graalvm@809afe62741147990fbf405045cd15e61bffedfe # v1.5.5
         with:
           java-version: "21"
       - name: run tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Set up GraalVM JDK 21
-        uses: graalvm/setup-graalvm@bef4b0e916c7dd079bf60fb95d49139f67e32c5f # v1
+        uses: graalvm/setup-graalvm@bef4b0e916c7dd079bf60fb95d49139f67e32c5f # v1.5.5
         with:
           java-version: "21"
       - name: run tests


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: 2024 PNED G.I.E. -->

<!-- SPDX-License-Identifier: Apache-2.0 -->

## 🚀 Pull Request Checklist

- **Title:**

  - `[x]` A brief, descriptive title for the changes.

- **Description:**

  - `[x]` Provide a clear and concise description of your pull request, including the purpose of the changes and the approach you've taken.

- **Context:**

  - `[x]` Why are these changes necessary? What problem do they solve? Link any related issues.

- **Changes:**

  - `[x]` List the major changes you've made, ideally organized by commit or feature.

- **Testing:**

  - `[x]` Describe how the changes have been tested. Include any relevant details about the testing environment and the test cases.

- **Screenshots (if applicable):**

  - `[ ]` If your changes are visual, include screenshots to help explain your changes.

- **Additional Information:**

  - `[x]` Add any other information that might be useful for reviewers, such as considerations, discussions, or dependencies.

- **Checklist:**
  - `[x]` I have checked that my code adheres to the project's style guidelines and that my code is well-commented.
  - `[x]` I have performed self-review of my own code and corrected any misspellings.
  - `[ ]` I have made corresponding changes to the documentation (if applicable).
  - `[x]` My changes generate no new warnings or errors.
  - `[ ]` I have added tests that prove my fix is effective or that my feature works.
  - `[x]` New and existing unit tests pass locally with my changes.

---

## Description

Fixes the failing `Run zizmor` GitHub Actions job by correcting the hash pin for `graalvm/setup-graalvm` in three workflow files. The hash `bef4b0e916c7dd079bf60fb95d49139f67e32c5f` did not correspond to the `v1.5.5` tag, causing zizmor to report a mismatched version comment and exit with code 13.

## Context

The `Run zizmor` CI job audits workflow files for security issues, including verifying that hash-pinned actions have accurate version comments. The hash pin for `graalvm/setup-graalvm` in `main.yml`, `release.yml`, and `test.yml` was set to an incorrect SHA that did not match the claimed `v1.5.5` tag. Zizmor detected the mismatch and failed the job.

## Changes

- **`.github/workflows/main.yml`** (line 51): Corrected `graalvm/setup-graalvm` hash from `bef4b0e916c7dd079bf60fb95d49139f67e32c5f` to `809afe62741147990fbf405045cd15e61bffedfe` to match `v1.5.5`.
- **`.github/workflows/release.yml`** (line 137): Same correction as above.
- **`.github/workflows/test.yml`** (line 22): Same correction as above.

## Testing

- Verified that the correct commit SHA for `graalvm/setup-graalvm@v1.5.5` is `809afe62741147990fbf405045cd15e61bffedfe` via the GitHub API.
- Zizmor will no longer report a mismatched version comment for these entries.

## Additional Information

The previous attempt to fix this issue only updated the version comment from `# v1` to `# v1.5.5` without correcting the underlying hash pin. This fix addresses the root cause by updating the hash to the commit SHA that `v1.5.5` actually resolves to.