### PR TITLE
Map nested dataset help texts

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,7 +48,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up GraalVM JDK 21
-        uses: graalvm/setup-graalvm@bef4b0e916c7dd079bf60fb95d49139f67e32c5f # v1
+        uses: graalvm/setup-graalvm@bef4b0e916c7dd079bf60fb95d49139f67e32c5f # v1.5.5
         with:
           java-version: "21"
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,7 +48,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up GraalVM JDK 21
-        uses: graalvm/setup-graalvm@bef4b0e916c7dd079bf60fb95d49139f67e32c5f # v1.5.5
+        uses: graalvm/setup-graalvm@809afe62741147990fbf405045cd15e61bffedfe # v1.5.5
         with:
           java-version: "21"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,7 +134,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up GraalVM JDK 21
-        uses: graalvm/setup-graalvm@bef4b0e916c7dd079bf60fb95d49139f67e32c5f # v1
+        uses: graalvm/setup-graalvm@bef4b0e916c7dd079bf60fb95d49139f67e32c5f # v1.5.5
         with:
           java-version: "21"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,7 +134,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up GraalVM JDK 21
-        uses: graalvm/setup-graalvm@bef4b0e916c7dd079bf60fb95d49139f67e32c5f # v1.5.5
+        uses: graalvm/setup-graalvm@809afe62741147990fbf405045cd15e61bffedfe # v1.5.5
         with:
           java-version: "21"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Set up GraalVM JDK 21
-        uses: graalvm/setup-graalvm@bef4b0e916c7dd079bf60fb95d49139f67e32c5f # v1.5.5
+        uses: graalvm/setup-graalvm@809afe62741147990fbf405045cd15e61bffedfe # v1.5.5
         with:
           java-version: "21"
       - name: run tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Set up GraalVM JDK 21
-        uses: graalvm/setup-graalvm@bef4b0e916c7dd079bf60fb95d49139f67e32c5f # v1
+        uses: graalvm/setup-graalvm@bef4b0e916c7dd079bf60fb95d49139f67e32c5f # v1.5.5
         with:
           java-version: "21"
       - name: run tests

--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/CkanDatasetHelpTextService.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/CkanDatasetHelpTextService.java
@@ -133,9 +133,7 @@ public class CkanDatasetHelpTextService {
 
     private String keysAsJson() {
         try {
-            return objectMapper.writeValueAsString(List.copyOf(
-                    SCHEMING_FIELD_TO_DATASET_PROPERTY.keySet()
-            ));
+            return objectMapper.writeValueAsString(SCHEMING_FIELD_TO_DATASET_PROPERTY.keySet());
         } catch (JsonProcessingException exception) {
             throw new IllegalStateException("Could not serialize dataset help-text keys for CKAN",
                     exception);

--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/CkanDatasetHelpTextService.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/CkanDatasetHelpTextService.java
@@ -124,8 +124,9 @@ public class CkanDatasetHelpTextService {
         var mappedHelpTexts = new LinkedHashMap<String, String>();
         helpTexts.forEach((fieldName, helpText) -> {
             var datasetProperty = SCHEMING_FIELD_TO_DATASET_PROPERTY.get(fieldName);
-            if (datasetProperty != null && StringUtils.isNotBlank(helpText)) {
-                mappedHelpTexts.put(datasetProperty, helpText);
+            var normalizedHelpText = StringUtils.normalizeSpace(helpText);
+            if (datasetProperty != null && StringUtils.isNotBlank(normalizedHelpText)) {
+                mappedHelpTexts.put(datasetProperty, normalizedHelpText);
             }
         });
         return mappedHelpTexts;

--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/CkanDatasetHelpTextService.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/CkanDatasetHelpTextService.java
@@ -1,0 +1,165 @@
+// SPDX-FileCopyrightText: 2026 Health-RI
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package io.github.genomicdatainfrastructure.discovery.datasets.infrastructure.ckan;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.genomicdatainfrastructure.discovery.model.RetrievedDataset;
+import io.github.genomicdatainfrastructure.discovery.remote.ckan.api.CkanQueryApi;
+import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.CkanFilterHelpTextsResponse;
+import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.CkanPackage;
+import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.CkanValueLabel;
+import jakarta.enterprise.context.ApplicationScoped;
+import lombok.extern.java.Log;
+import org.apache.commons.lang3.StringUtils;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.logging.Level;
+
+@Log
+@ApplicationScoped
+public class CkanDatasetHelpTextService {
+
+    private static final String DEFAULT_DATASET_TYPE = "dataset";
+
+    private static final Map<String, String> SCHEMING_FIELD_TO_DATASET_PROPERTY = Map.ofEntries(
+            Map.entry("title_translated", "title"),
+            Map.entry("notes_translated", "description"),
+            Map.entry("tags_translated", "keywords"),
+            Map.entry("contact", "contacts"),
+            Map.entry("publisher", "publishers"),
+            Map.entry("owner_org", "ownerOrg"),
+            Map.entry("url", "url"),
+            Map.entry("issued", "createdAt"),
+            Map.entry("modified", "modifiedAt"),
+            Map.entry("version", "version"),
+            Map.entry("version_notes", "versionNotes"),
+            Map.entry("identifier", "identifier"),
+            Map.entry("frequency", "frequency"),
+            Map.entry("provenance", "provenance"),
+            Map.entry("dcat_type", "dcatType"),
+            Map.entry("temporal_coverage", "temporalCoverage"),
+            Map.entry("temporal_resolution", "temporalResolution"),
+            Map.entry("spatial_coverage", "spatialCoverage"),
+            Map.entry("spatial_resolution_in_meters", "spatialResolutionInMeters"),
+            Map.entry("access_rights", "accessRights"),
+            Map.entry("alternate_identifier", "alternateIdentifier"),
+            Map.entry("theme", "themes"),
+            Map.entry("language", "languages"),
+            Map.entry("documentation", "documentation"),
+            Map.entry("conforms_to", "conformsTo"),
+            Map.entry("is_referenced_by", "isReferencedBy"),
+            Map.entry("distribution", "distributions"),
+            Map.entry("sample", "samples"),
+            Map.entry("analytics", "analytics"),
+            Map.entry("applicable_legislation", "applicableLegislation"),
+            Map.entry("has_version", "hasVersions"),
+            Map.entry("code_values", "codeValues"),
+            Map.entry("coding_system", "codingSystem"),
+            Map.entry("purpose", "purpose"),
+            Map.entry("health_category", "healthCategory"),
+            Map.entry("health_theme", "healthTheme"),
+            Map.entry("legal_basis", "legalBasis"),
+            Map.entry("min_typical_age", "minTypicalAge"),
+            Map.entry("max_typical_age", "maxTypicalAge"),
+            Map.entry("number_of_records", "numberOfRecords"),
+            Map.entry("number_of_unique_individuals", "numberOfUniqueIndividuals"),
+            Map.entry("personal_data", "personalData"),
+            Map.entry("trusted_data_holder", "trustedDataHolder"),
+            Map.entry("population_coverage", "populationCoverage"),
+            Map.entry("retention_period", "retentionPeriod"),
+            Map.entry("hdab", "hdab"),
+            Map.entry("qualified_relation", "qualifiedRelation"),
+            Map.entry("provenance_activity", "provenanceActivity"),
+            Map.entry("qualified_attribution", "qualifiedAttribution"),
+            Map.entry("quality_annotation", "qualityAnnotation"),
+            Map.entry("uri", "uri")
+    );
+
+    private final CkanQueryApi ckanQueryApi;
+    private final ObjectMapper objectMapper;
+
+    public CkanDatasetHelpTextService(@RestClient CkanQueryApi ckanQueryApi,
+            ObjectMapper objectMapper) {
+        this.ckanQueryApi = ckanQueryApi;
+        this.objectMapper = objectMapper;
+    }
+
+    public RetrievedDataset enrich(RetrievedDataset dataset, CkanPackage ckanPackage,
+            String preferredLanguage) {
+        if (dataset == null || ckanPackage == null) {
+            return dataset;
+        }
+
+        var helpTexts = retrieveHelpTexts(ckanPackage, preferredLanguage);
+        if (!helpTexts.isEmpty()) {
+            dataset.setHelpText(helpTexts);
+        }
+        return dataset;
+    }
+
+    private Map<String, String> retrieveHelpTexts(CkanPackage ckanPackage,
+            String preferredLanguage) {
+        try {
+            return mapToDatasetProperties(Optional.ofNullable(ckanQueryApi.gdiDatasetHelpTextsShow(
+                    preferredLanguage,
+                    schemingType(ckanPackage),
+                    keysAsJson()
+            ))
+                    .map(CkanFilterHelpTextsResponse::getResult)
+                    .orElseGet(Map::of));
+        } catch (RuntimeException exception) {
+            log.log(Level.WARNING, "Could not retrieve CKAN dataset help texts", exception);
+            return Map.of();
+        }
+    }
+
+    private Map<String, String> mapToDatasetProperties(Map<String, String> helpTexts) {
+        var mappedHelpTexts = new LinkedHashMap<String, String>();
+        helpTexts.forEach((fieldName, helpText) -> {
+            var datasetProperty = SCHEMING_FIELD_TO_DATASET_PROPERTY.get(fieldName);
+            if (datasetProperty != null && StringUtils.isNotBlank(helpText)) {
+                mappedHelpTexts.put(datasetProperty, helpText);
+            }
+        });
+        return mappedHelpTexts;
+    }
+
+    private String keysAsJson() {
+        try {
+            return objectMapper.writeValueAsString(List.copyOf(
+                    SCHEMING_FIELD_TO_DATASET_PROPERTY.keySet()
+            ));
+        } catch (JsonProcessingException exception) {
+            throw new IllegalStateException("Could not serialize dataset help-text keys for CKAN",
+                    exception);
+        }
+    }
+
+    private String schemingType(CkanPackage ckanPackage) {
+        return Optional.ofNullable(ckanPackage.getType())
+                .map(this::typeName)
+                .filter(StringUtils::isNotBlank)
+                .orElse(DEFAULT_DATASET_TYPE);
+    }
+
+    private String typeName(CkanValueLabel type) {
+        return firstNotBlank(type.getName(), type.getDisplayName())
+                .orElse(DEFAULT_DATASET_TYPE);
+    }
+
+    private Optional<String> firstNotBlank(String... values) {
+        for (String value : values) {
+            if (StringUtils.isNotBlank(value)) {
+                return Optional.of(value.trim());
+            }
+        }
+        return Optional.empty();
+    }
+}

--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/CkanDatasetHelpTextService.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/CkanDatasetHelpTextService.java
@@ -27,60 +27,93 @@ import java.util.logging.Level;
 public class CkanDatasetHelpTextService {
 
     private static final String DEFAULT_DATASET_TYPE = "dataset";
+    private static final String DATASET_SERIES_TYPE = "dataset_series";
 
-    private static final Map<String, String> SCHEMING_FIELD_TO_DATASET_PROPERTY = Map.ofEntries(
-            Map.entry("title_translated", "title"),
-            Map.entry("notes_translated", "description"),
-            Map.entry("tags_translated", "keywords"),
-            Map.entry("contact", "contacts"),
-            Map.entry("publisher", "publishers"),
-            Map.entry("owner_org", "ownerOrg"),
-            Map.entry("url", "url"),
-            Map.entry("issued", "createdAt"),
-            Map.entry("modified", "modifiedAt"),
-            Map.entry("version", "version"),
-            Map.entry("version_notes", "versionNotes"),
-            Map.entry("identifier", "identifier"),
-            Map.entry("frequency", "frequency"),
-            Map.entry("provenance", "provenance"),
-            Map.entry("dcat_type", "dcatType"),
-            Map.entry("temporal_coverage", "temporalCoverage"),
-            Map.entry("temporal_resolution", "temporalResolution"),
-            Map.entry("spatial_coverage", "spatialCoverage"),
-            Map.entry("spatial_resolution_in_meters", "spatialResolutionInMeters"),
-            Map.entry("access_rights", "accessRights"),
-            Map.entry("alternate_identifier", "alternateIdentifier"),
-            Map.entry("theme", "themes"),
-            Map.entry("language", "languages"),
-            Map.entry("documentation", "documentation"),
-            Map.entry("conforms_to", "conformsTo"),
-            Map.entry("is_referenced_by", "isReferencedBy"),
-            Map.entry("distribution", "distributions"),
-            Map.entry("sample", "samples"),
-            Map.entry("analytics", "analytics"),
-            Map.entry("applicable_legislation", "applicableLegislation"),
-            Map.entry("has_version", "hasVersions"),
-            Map.entry("code_values", "codeValues"),
-            Map.entry("coding_system", "codingSystem"),
-            Map.entry("purpose", "purpose"),
-            Map.entry("health_category", "healthCategory"),
-            Map.entry("health_theme", "healthTheme"),
-            Map.entry("legal_basis", "legalBasis"),
-            Map.entry("min_typical_age", "minTypicalAge"),
-            Map.entry("max_typical_age", "maxTypicalAge"),
-            Map.entry("number_of_records", "numberOfRecords"),
-            Map.entry("number_of_unique_individuals", "numberOfUniqueIndividuals"),
-            Map.entry("personal_data", "personalData"),
-            Map.entry("trusted_data_holder", "trustedDataHolder"),
-            Map.entry("population_coverage", "populationCoverage"),
-            Map.entry("retention_period", "retentionPeriod"),
-            Map.entry("hdab", "hdab"),
-            Map.entry("qualified_relation", "qualifiedRelation"),
-            Map.entry("provenance_activity", "provenanceActivity"),
-            Map.entry("qualified_attribution", "qualifiedAttribution"),
-            Map.entry("quality_annotation", "qualityAnnotation"),
-            Map.entry("uri", "uri")
-    );
+    private static final Map<String, List<String>> SCHEMING_FIELD_TO_DATASET_PROPERTY = Map
+            .ofEntries(
+                    Map.entry("title_translated", List.of("title")),
+                    Map.entry("notes_translated", List.of("description")),
+                    Map.entry("tags_translated", List.of("keywords")),
+                    Map.entry("contact", List.of("contacts")),
+                    Map.entry("publisher", List.of("publishers")),
+                    Map.entry("owner_org", List.of("ownerOrg")),
+                    Map.entry("url", List.of("url")),
+                    Map.entry("issued", List.of("createdAt")),
+                    Map.entry("modified", List.of("modifiedAt")),
+                    Map.entry("version", List.of("version")),
+                    Map.entry("version_notes", List.of("versionNotes")),
+                    Map.entry("identifier", List.of("identifier")),
+                    Map.entry("frequency", List.of("frequency")),
+                    Map.entry("provenance", List.of("provenance")),
+                    Map.entry("dcat_type", List.of("dcatType")),
+                    Map.entry("temporal_coverage", List.of("temporalCoverage")),
+                    Map.entry("temporal_resolution", List.of("temporalResolution")),
+                    Map.entry("spatial_coverage", List.of("spatialCoverage")),
+                    Map.entry("spatial_resolution_in_meters", List.of("spatialResolutionInMeters")),
+                    Map.entry("access_rights", List.of("accessRights")),
+                    Map.entry("alternate_identifier", List.of("alternateIdentifier")),
+                    Map.entry("theme", List.of("themes")),
+                    Map.entry("language", List.of("languages")),
+                    Map.entry("documentation", List.of("documentation")),
+                    Map.entry("conforms_to", List.of("conformsTo")),
+                    Map.entry("is_referenced_by", List.of("isReferencedBy")),
+                    Map.entry("distribution", List.of("distributions")),
+                    Map.entry("sample", List.of("samples")),
+                    Map.entry("analytics", List.of("analytics")),
+                    Map.entry("applicable_legislation", List.of("applicableLegislation")),
+                    Map.entry("has_version", List.of("hasVersions")),
+                    Map.entry("code_values", List.of("codeValues")),
+                    Map.entry("coding_system", List.of("codingSystem")),
+                    Map.entry("purpose", List.of("purpose")),
+                    Map.entry("health_category", List.of("healthCategory")),
+                    Map.entry("health_theme", List.of("healthTheme")),
+                    Map.entry("legal_basis", List.of("legalBasis")),
+                    Map.entry("min_typical_age", List.of("minTypicalAge")),
+                    Map.entry("max_typical_age", List.of("maxTypicalAge")),
+                    Map.entry("number_of_records", List.of("numberOfRecords")),
+                    Map.entry("number_of_unique_individuals", List.of("numberOfUniqueIndividuals")),
+                    Map.entry("personal_data", List.of("personalData")),
+                    Map.entry("trusted_data_holder", List.of("trustedDataHolder")),
+                    Map.entry("population_coverage", List.of("populationCoverage")),
+                    Map.entry("retention_period", List.of("retentionPeriod")),
+                    Map.entry("hdab", List.of("hdab")),
+                    Map.entry("qualified_relation", List.of("qualifiedRelation")),
+                    Map.entry("provenance_activity", List.of("provenanceActivity")),
+                    Map.entry("qualified_attribution", List.of("qualifiedAttribution")),
+                    Map.entry("quality_annotation", List.of("qualityAnnotation")),
+                    Map.entry("uri", List.of("uri")),
+                    Map.entry("in_series", List.of("inSeries")),
+                    Map.entry("resource_fields.name_translated",
+                            List.of("distributions.title", "samples.title", "analytics.title")),
+                    Map.entry("resource_fields.description_translated",
+                            List.of("distributions.description", "samples.description",
+                                    "analytics.description")),
+                    Map.entry("resource_fields.format",
+                            List.of("distributions.format", "samples.format", "analytics.format")),
+                    Map.entry("resource_fields.download_url",
+                            List.of("distributions.downloadUrl", "samples.downloadUrl",
+                                    "analytics.downloadUrl")),
+                    Map.entry("resource_fields.access_services", List.of(
+                            "distributions.accessService")),
+                    Map.entry("resource_fields.access_services.title",
+                            List.of("distributions.accessService.title")),
+                    Map.entry("resource_fields.access_services.description",
+                            List.of("distributions.accessService.description"))
+            );
+
+    private static final Map<String, List<String>> SERIES_FIELD_TO_IN_SERIES_PROPERTY = Map
+            .ofEntries(
+                    Map.entry("title_translated", List.of("inSeries.title")),
+                    Map.entry("notes_translated", List.of("inSeries.description")),
+                    Map.entry("frequency", List.of("inSeries.frequency")),
+                    Map.entry("temporal_coverage", List.of("inSeries.temporalCoverage")),
+                    Map.entry("applicable_legislation", List.of("inSeries.applicableLegislation")),
+                    Map.entry("contact", List.of("inSeries.contacts")),
+                    Map.entry("publisher", List.of("inSeries.publishers")),
+                    Map.entry("issued", List.of("inSeries.issued")),
+                    Map.entry("modified", List.of("inSeries.modified")),
+                    Map.entry("spatial_coverage", List.of("inSeries.spatial"))
+            );
 
     private final CkanQueryApi ckanQueryApi;
     private final ObjectMapper objectMapper;
@@ -106,35 +139,71 @@ public class CkanDatasetHelpTextService {
 
     private Map<String, String> retrieveHelpTexts(CkanPackage ckanPackage,
             String preferredLanguage) {
+        var helpTexts = new LinkedHashMap<String, String>();
+        helpTexts.putAll(retrievePackageHelpTexts(ckanPackage, preferredLanguage));
+        helpTexts.putAll(retrieveJoinedSeriesHelpTexts(ckanPackage, preferredLanguage));
+        return helpTexts;
+    }
+
+    private Map<String, String> retrievePackageHelpTexts(CkanPackage ckanPackage,
+            String preferredLanguage) {
         try {
-            return mapToDatasetProperties(Optional.ofNullable(ckanQueryApi.gdiDatasetHelpTextsShow(
-                    preferredLanguage,
-                    schemingType(ckanPackage),
-                    keysAsJson()
-            ))
-                    .map(CkanFilterHelpTextsResponse::getResult)
-                    .orElseGet(Map::of));
+            return mapToDatasetProperties(
+                    Optional.ofNullable(ckanQueryApi.gdiDatasetHelpTextsShow(
+                            preferredLanguage,
+                            schemingType(ckanPackage),
+                            keysAsJson(SCHEMING_FIELD_TO_DATASET_PROPERTY)
+                    ))
+                            .map(CkanFilterHelpTextsResponse::getResult)
+                            .orElseGet(Map::of),
+                    SCHEMING_FIELD_TO_DATASET_PROPERTY
+            );
         } catch (RuntimeException exception) {
             log.log(Level.WARNING, "Could not retrieve CKAN dataset help texts", exception);
             return Map.of();
         }
     }
 
-    private Map<String, String> mapToDatasetProperties(Map<String, String> helpTexts) {
+    private Map<String, String> retrieveJoinedSeriesHelpTexts(CkanPackage ckanPackage,
+            String preferredLanguage) {
+        if (ckanPackage.getInSeries() == null || ckanPackage.getInSeries().isEmpty()) {
+            return Map.of();
+        }
+
+        try {
+            return mapToDatasetProperties(
+                    Optional.ofNullable(ckanQueryApi.gdiDatasetHelpTextsShow(
+                            preferredLanguage,
+                            DATASET_SERIES_TYPE,
+                            keysAsJson(SERIES_FIELD_TO_IN_SERIES_PROPERTY)
+                    ))
+                            .map(CkanFilterHelpTextsResponse::getResult)
+                            .orElseGet(Map::of),
+                    SERIES_FIELD_TO_IN_SERIES_PROPERTY
+            );
+        } catch (RuntimeException exception) {
+            log.log(Level.WARNING, "Could not retrieve CKAN dataset series help texts", exception);
+            return Map.of();
+        }
+    }
+
+    private Map<String, String> mapToDatasetProperties(Map<String, String> helpTexts,
+            Map<String, List<String>> fieldMappings) {
         var mappedHelpTexts = new LinkedHashMap<String, String>();
         helpTexts.forEach((fieldName, helpText) -> {
-            var datasetProperty = SCHEMING_FIELD_TO_DATASET_PROPERTY.get(fieldName);
+            var datasetProperties = fieldMappings.get(fieldName);
             var normalizedHelpText = StringUtils.normalizeSpace(helpText);
-            if (datasetProperty != null && StringUtils.isNotBlank(normalizedHelpText)) {
-                mappedHelpTexts.put(datasetProperty, normalizedHelpText);
+            if (datasetProperties != null && StringUtils.isNotBlank(normalizedHelpText)) {
+                datasetProperties.forEach(datasetProperty -> mappedHelpTexts.put(datasetProperty,
+                        normalizedHelpText));
             }
         });
         return mappedHelpTexts;
     }
 
-    private String keysAsJson() {
+    private String keysAsJson(Map<String, List<String>> fieldMappings) {
         try {
-            return objectMapper.writeValueAsString(SCHEMING_FIELD_TO_DATASET_PROPERTY.keySet());
+            return objectMapper.writeValueAsString(fieldMappings.keySet());
         } catch (JsonProcessingException exception) {
             throw new IllegalStateException("Could not serialize dataset help-text keys for CKAN",
                     exception);

--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/mapper/CkanDatasetsMapper.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/mapper/CkanDatasetsMapper.java
@@ -85,6 +85,7 @@ public interface CkanDatasetsMapper {
     @Mapping(target = "version", source = "version")
     @Mapping(target = "ownerOrg", source = "ownerOrg")
     @Mapping(target = "isSeries", source = ".", qualifiedByName = "isDatasetSeries")
+    @Mapping(target = "helpText", ignore = true)
     RetrievedDataset map(CkanPackage ckanPackage);
 
     @Mapping(target = "contacts", source = "contact")

--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/persistence/CkanDatasetsRepository.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/persistence/CkanDatasetsRepository.java
@@ -6,6 +6,7 @@ package io.github.genomicdatainfrastructure.discovery.datasets.infrastructure.ck
 
 import io.github.genomicdatainfrastructure.discovery.datasets.application.ports.DatasetsRepository;
 import io.github.genomicdatainfrastructure.discovery.datasets.domain.exceptions.DatasetNotFoundException;
+import io.github.genomicdatainfrastructure.discovery.datasets.infrastructure.ckan.CkanDatasetHelpTextService;
 import io.github.genomicdatainfrastructure.discovery.datasets.infrastructure.ckan.mapper.CkanDatasetsMapper;
 import io.github.genomicdatainfrastructure.discovery.filters.infrastructure.ckan.CkanFilterHelpTextService;
 import io.github.genomicdatainfrastructure.discovery.filters.infrastructure.ckan.CkanSearchFacetsMapper;
@@ -31,18 +32,21 @@ public class CkanDatasetsRepository implements DatasetsRepository {
     private final CkanDatasetsMapper ckanDatasetsMapper;
     private final CkanSearchFacetsMapper ckanSearchFacetsMapper;
     private final CkanFilterHelpTextService ckanFilterHelpTextService;
+    private final CkanDatasetHelpTextService ckanDatasetHelpTextService;
 
     @Inject
     public CkanDatasetsRepository(
             @RestClient CkanQueryApi ckanQueryApi,
             CkanDatasetsMapper ckanDatasetsMapper,
             CkanSearchFacetsMapper ckanSearchFacetsMapper,
-            CkanFilterHelpTextService ckanFilterHelpTextService
+            CkanFilterHelpTextService ckanFilterHelpTextService,
+            CkanDatasetHelpTextService ckanDatasetHelpTextService
     ) {
         this.ckanQueryApi = ckanQueryApi;
         this.ckanDatasetsMapper = ckanDatasetsMapper;
         this.ckanSearchFacetsMapper = ckanSearchFacetsMapper;
         this.ckanFilterHelpTextService = ckanFilterHelpTextService;
+        this.ckanDatasetHelpTextService = ckanDatasetHelpTextService;
     }
 
     @Override
@@ -129,6 +133,11 @@ public class CkanDatasetsRepository implements DatasetsRepository {
         try {
             var ckanPackage = ckanQueryApi.packageShow(id, preferredLanguage);
             var mappedDataset = ckanDatasetsMapper.map(ckanPackage.getResult());
+            ckanDatasetHelpTextService.enrich(
+                    mappedDataset,
+                    ckanPackage.getResult(),
+                    preferredLanguage
+            );
             var inSeries = ofNullable(ckanPackage.getResult().getInSeries())
                     .orElse(List.of())
                     .stream()

--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/filters/infrastructure/ckan/CkanFilterHelpTextService.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/filters/infrastructure/ckan/CkanFilterHelpTextService.java
@@ -13,6 +13,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.ws.rs.ProcessingException;
 import jakarta.ws.rs.WebApplicationException;
 import lombok.extern.java.Log;
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 
 import java.util.List;
@@ -43,7 +44,8 @@ public class CkanFilterHelpTextService {
             return filters;
         }
 
-        filters.forEach(filter -> filter.setHelpText(helpTexts.get(filter.getKey())));
+        filters.forEach(filter -> filter.setHelpText(normalizeHelpText(helpTexts.get(filter
+                .getKey()))));
         return filters;
     }
 
@@ -76,5 +78,10 @@ public class CkanFilterHelpTextService {
         } catch (JsonProcessingException exception) {
             throw new IllegalStateException("Could not serialize filter keys for CKAN", exception);
         }
+    }
+
+    private String normalizeHelpText(String helpText) {
+        var normalizedHelpText = StringUtils.normalizeSpace(helpText);
+        return StringUtils.isBlank(normalizedHelpText) ? null : normalizedHelpText;
     }
 }

--- a/src/main/openapi/ckan.yaml
+++ b/src/main/openapi/ckan.yaml
@@ -79,6 +79,35 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/CkanFilterHelpTextsResponse"
+  /api/3/action/gdi_dataset_help_texts_show:
+    get:
+      summary: Retrieves localized help texts for dataset fields
+      operationId: gdi_dataset_help_texts_show
+      tags:
+        - "ckan-query"
+      parameters:
+        - $ref: "#/components/parameters/AcceptLanguage"
+        - name: type
+          in: query
+          description: CKAN scheming dataset type
+          required: false
+          schema:
+            type: string
+            example: dataset
+        - name: keys
+          in: query
+          description: JSON array of scheming field names to retrieve help text for
+          required: false
+          schema:
+            type: string
+            example: '["title_translated"]'
+      responses:
+        "200":
+          description: Localized help text keyed by scheming field name
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CkanFilterHelpTextsResponse"
   /dataset/{id}.{format}:
     get:
       summary: Retrieves a dataset by its ID, in the requested format

--- a/src/main/openapi/discovery.yaml
+++ b/src/main/openapi/discovery.yaml
@@ -449,6 +449,11 @@ components:
         description:
           type: string
           title: Description
+        helpText:
+          type: object
+          title: Help text
+          additionalProperties:
+            type: string
         version:
           type: string
           title: Version

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -70,21 +70,19 @@ quarkus.otel.metrics.enabled=true
 # Custom Application Properties
 sources.beacon=true
 app.accept-language.default=en-GB
-datasets.filters=title,access_rights,theme,tags,publisher_name,res_format,modified,number_of_records,vocab_in_series_title
+datasets.filters=access_rights,theme,tags,publisher_name,res_format,modified,number_of_records,vocab_in_series_title
 datasets.no-group-key=NO_GROUP
 datasets.filter-groups[0].key=DEFAULT
-datasets.filter-groups[0].filters[0].key=title
-datasets.filter-groups[0].filters[0].type=free_text
-datasets.filter-groups[0].filters[1].key=access_rights
-datasets.filter-groups[0].filters[2].key=theme
-datasets.filter-groups[0].filters[3].key=tags
-datasets.filter-groups[0].filters[4].key=publisher_name
-datasets.filter-groups[0].filters[5].key=res_format
-datasets.filter-groups[0].filters[6].key=modified
-datasets.filter-groups[0].filters[6].type=datetime
-datasets.filter-groups[0].filters[7].key=number_of_records
-datasets.filter-groups[0].filters[7].type=number
-datasets.filter-groups[0].filters[8].key=vocab_in_series_title
+datasets.filter-groups[0].filters[0].key=access_rights
+datasets.filter-groups[0].filters[1].key=theme
+datasets.filter-groups[0].filters[2].key=tags
+datasets.filter-groups[0].filters[3].key=publisher_name
+datasets.filter-groups[0].filters[4].key=res_format
+datasets.filter-groups[0].filters[5].key=modified
+datasets.filter-groups[0].filters[5].type=datetime
+datasets.filter-groups[0].filters[6].key=number_of_records
+datasets.filter-groups[0].filters[6].type=number
+datasets.filter-groups[0].filters[7].key=vocab_in_series_title
 
 # Development Profile Specific Configuration
 %dev.quarkus.oidc.auth-server-url=https://id.portal.dev.gdi.lu/realms/gdi

--- a/src/test/java/io/github/genomicdatainfrastructure/discovery/api/RetrieveDatasetTest.java
+++ b/src/test/java/io/github/genomicdatainfrastructure/discovery/api/RetrieveDatasetTest.java
@@ -24,7 +24,22 @@ class RetrieveDatasetTest extends BaseTest {
                 .statusCode(200)
                 .body("helpText.title", equalTo("A descriptive title for the dataset."))
                 .body("helpText.accessRights",
-                        equalTo("Information that indicates whether the dataset is open or restricted."));
+                        equalTo("Information that indicates whether the dataset is open or restricted."))
+                .body("helpText.inSeries", equalTo("Dataset series this dataset belongs to."))
+                .body("helpText['distributions.title']",
+                        equalTo("A descriptive title for the resource."))
+                .body("helpText['samples.title']",
+                        equalTo("A descriptive title for the resource."))
+                .body("helpText['analytics.title']",
+                        equalTo("A descriptive title for the resource."))
+                .body("helpText['distributions.format']",
+                        equalTo("File format. If not provided it will be guessed."))
+                .body("helpText['distributions.accessService.title']",
+                        equalTo("A title for the data service."))
+                .body("helpText['inSeries.title']",
+                        equalTo("A descriptive title for the dataset series."))
+                .body("helpText['inSeries.frequency']",
+                        equalTo("The frequency with which items are added to the dataset series collection."));
     }
 
     @Test

--- a/src/test/java/io/github/genomicdatainfrastructure/discovery/api/RetrieveDatasetTest.java
+++ b/src/test/java/io/github/genomicdatainfrastructure/discovery/api/RetrieveDatasetTest.java
@@ -21,7 +21,10 @@ class RetrieveDatasetTest extends BaseTest {
                 .when()
                 .get("/api/v1/datasets/e1b3eff9-13eb-48b0-b180-7ecb76b84454")
                 .then()
-                .statusCode(200);
+                .statusCode(200)
+                .body("helpText.title", equalTo("A descriptive title for the dataset."))
+                .body("helpText.accessRights",
+                        equalTo("Information that indicates whether the dataset is open or restricted."));
     }
 
     @Test

--- a/src/test/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/CkanDatasetHelpTextServiceTest.java
+++ b/src/test/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/CkanDatasetHelpTextServiceTest.java
@@ -1,0 +1,120 @@
+// SPDX-FileCopyrightText: 2026 Health-RI
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package io.github.genomicdatainfrastructure.discovery.datasets.infrastructure.ckan;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.genomicdatainfrastructure.discovery.model.RetrievedDataset;
+import io.github.genomicdatainfrastructure.discovery.remote.ckan.api.CkanQueryApi;
+import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.CkanFilterHelpTextsResponse;
+import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.CkanPackage;
+import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.CkanValueLabel;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+class CkanDatasetHelpTextServiceTest {
+
+    @Test
+    void enrichMapsCkanFieldNamesToDatasetPropertyNames() {
+        var ckanQueryApi = mock(CkanQueryApi.class);
+        var service = new CkanDatasetHelpTextService(ckanQueryApi, new ObjectMapper());
+        var dataset = RetrievedDataset.builder().id("dataset-1").build();
+        var ckanPackage = CkanPackage.builder()
+                .type(CkanValueLabel.builder().name("dataset_series").build())
+                .build();
+
+        when(ckanQueryApi.gdiDatasetHelpTextsShow(anyString(), anyString(), anyString()))
+                .thenReturn(CkanFilterHelpTextsResponse.builder()
+                        .result(Map.of(
+                                "title_translated", "A descriptive title.",
+                                "access_rights", "Access conditions.",
+                                "unknown_field", "Not exposed."
+                        ))
+                        .build());
+
+        service.enrich(dataset, ckanPackage, "nl");
+
+        assertThat(dataset.getHelpText())
+                .containsEntry("title", "A descriptive title.")
+                .containsEntry("accessRights", "Access conditions.")
+                .doesNotContainKey("unknown_field");
+    }
+
+    @Test
+    void enrichForwardsPreferredLanguageDatasetTypeAndRequestedKeys() {
+        var ckanQueryApi = mock(CkanQueryApi.class);
+        var service = new CkanDatasetHelpTextService(ckanQueryApi, new ObjectMapper());
+        var capturedLanguage = new String[1];
+        var capturedType = new String[1];
+        var capturedKeys = new String[1];
+
+        when(ckanQueryApi.gdiDatasetHelpTextsShow(anyString(), anyString(), anyString()))
+                .thenAnswer(invocation -> {
+                    capturedLanguage[0] = invocation.getArgument(0, String.class);
+                    capturedType[0] = invocation.getArgument(1, String.class);
+                    capturedKeys[0] = invocation.getArgument(2, String.class);
+                    return CkanFilterHelpTextsResponse.builder()
+                            .result(Map.of())
+                            .build();
+                });
+
+        service.enrich(
+                RetrievedDataset.builder().id("dataset-1").build(),
+                CkanPackage.builder()
+                        .type(CkanValueLabel.builder().name("dataset_series").build())
+                        .build(),
+                "nl"
+        );
+
+        assertThat(capturedLanguage[0]).isEqualTo("nl");
+        assertThat(capturedType[0]).isEqualTo("dataset_series");
+        assertThat(capturedKeys[0])
+                .contains("\"title_translated\"")
+                .contains("\"access_rights\"");
+    }
+
+    @Test
+    void enrichFallsBackToDatasetTypeWhenCkanPackageHasNoType() {
+        var ckanQueryApi = mock(CkanQueryApi.class);
+        var service = new CkanDatasetHelpTextService(ckanQueryApi, new ObjectMapper());
+        var capturedType = new String[1];
+
+        when(ckanQueryApi.gdiDatasetHelpTextsShow(anyString(), anyString(), anyString()))
+                .thenAnswer(invocation -> {
+                    capturedType[0] = invocation.getArgument(1, String.class);
+                    return CkanFilterHelpTextsResponse.builder()
+                            .result(Map.of())
+                            .build();
+                });
+
+        service.enrich(
+                RetrievedDataset.builder().id("dataset-1").build(),
+                CkanPackage.builder().build(),
+                "en"
+        );
+
+        assertThat(capturedType[0]).isEqualTo("dataset");
+    }
+
+    @Test
+    void enrichLeavesDatasetUnchangedWhenCkanHelpTextRequestFails() {
+        var ckanQueryApi = mock(CkanQueryApi.class);
+        var service = new CkanDatasetHelpTextService(ckanQueryApi, new ObjectMapper());
+        var dataset = RetrievedDataset.builder().id("dataset-1").build();
+
+        when(ckanQueryApi.gdiDatasetHelpTextsShow(anyString(), anyString(), anyString()))
+                .thenThrow(new RuntimeException("CKAN unavailable"));
+
+        var result = service.enrich(dataset, CkanPackage.builder().build(), "en");
+
+        assertThat(result).isSameAs(dataset);
+        assertThat(dataset.getHelpText()).isNull();
+    }
+}

--- a/src/test/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/CkanDatasetHelpTextServiceTest.java
+++ b/src/test/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/CkanDatasetHelpTextServiceTest.java
@@ -17,6 +17,7 @@ import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.CkanPacka
 import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.CkanValueLabel;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
 import java.util.Map;
 
 class CkanDatasetHelpTextServiceTest {
@@ -35,6 +36,11 @@ class CkanDatasetHelpTextServiceTest {
                         .result(Map.of(
                                 "title_translated", "A descriptive title.",
                                 "access_rights", "Access conditions.",
+                                "in_series", "Dataset series this dataset belongs to.",
+                                "resource_fields.name_translated", "A resource title.",
+                                "resource_fields.format", "Resource format.",
+                                "resource_fields.access_services.title",
+                                "A data service title.",
                                 "unknown_field", "Not exposed."
                         ))
                         .build());
@@ -44,6 +50,14 @@ class CkanDatasetHelpTextServiceTest {
         assertThat(dataset.getHelpText())
                 .containsEntry("title", "A descriptive title.")
                 .containsEntry("accessRights", "Access conditions.")
+                .containsEntry("inSeries", "Dataset series this dataset belongs to.")
+                .containsEntry("distributions.title", "A resource title.")
+                .containsEntry("samples.title", "A resource title.")
+                .containsEntry("analytics.title", "A resource title.")
+                .containsEntry("distributions.format", "Resource format.")
+                .containsEntry("samples.format", "Resource format.")
+                .containsEntry("analytics.format", "Resource format.")
+                .containsEntry("distributions.accessService.title", "A data service title.")
                 .doesNotContainKey("unknown_field");
     }
 
@@ -106,7 +120,80 @@ class CkanDatasetHelpTextServiceTest {
         assertThat(capturedType[0]).isEqualTo("dataset_series");
         assertThat(capturedKeys[0])
                 .contains("\"title_translated\"")
-                .contains("\"access_rights\"");
+                .contains("\"access_rights\"")
+                .contains("\"resource_fields.name_translated\"")
+                .contains("\"resource_fields.access_services.title\"");
+    }
+
+    @Test
+    void enrichAddsJoinedDatasetSeriesHelpTextWithInSeriesPrefix() {
+        var ckanQueryApi = mock(CkanQueryApi.class);
+        var service = new CkanDatasetHelpTextService(ckanQueryApi, new ObjectMapper());
+        var dataset = RetrievedDataset.builder().id("dataset-1").build();
+
+        when(ckanQueryApi.gdiDatasetHelpTextsShow(anyString(), anyString(), anyString()))
+                .thenAnswer(invocation -> {
+                    var type = invocation.getArgument(1, String.class);
+                    if ("dataset_series".equals(type)) {
+                        return CkanFilterHelpTextsResponse.builder()
+                                .result(Map.of(
+                                        "title_translated",
+                                        "A descriptive title for the dataset series.",
+                                        "notes_translated", "A description of the dataset series.",
+                                        "frequency", "The series publication frequency.",
+                                        "temporal_coverage",
+                                        "The temporal period the series covers."
+                                ))
+                                .build();
+                    }
+
+                    return CkanFilterHelpTextsResponse.builder()
+                            .result(Map.of("title_translated", "A descriptive title."))
+                            .build();
+                });
+
+        service.enrich(
+                dataset,
+                CkanPackage.builder().inSeries(List.of("series-1")).build(),
+                "en"
+        );
+
+        assertThat(dataset.getHelpText())
+                .containsEntry("title", "A descriptive title.")
+                .containsEntry("inSeries.title", "A descriptive title for the dataset series.")
+                .containsEntry("inSeries.description", "A description of the dataset series.")
+                .containsEntry("inSeries.frequency", "The series publication frequency.")
+                .containsEntry("inSeries.temporalCoverage",
+                        "The temporal period the series covers.");
+    }
+
+    @Test
+    void enrichKeepsDatasetHelpTextWhenJoinedSeriesHelpTextRequestFails() {
+        var ckanQueryApi = mock(CkanQueryApi.class);
+        var service = new CkanDatasetHelpTextService(ckanQueryApi, new ObjectMapper());
+        var dataset = RetrievedDataset.builder().id("dataset-1").build();
+
+        when(ckanQueryApi.gdiDatasetHelpTextsShow(anyString(), anyString(), anyString()))
+                .thenAnswer(invocation -> {
+                    var type = invocation.getArgument(1, String.class);
+                    if ("dataset_series".equals(type)) {
+                        throw new RuntimeException("CKAN unavailable");
+                    }
+
+                    return CkanFilterHelpTextsResponse.builder()
+                            .result(Map.of("title_translated", "A descriptive title."))
+                            .build();
+                });
+
+        service.enrich(
+                dataset,
+                CkanPackage.builder().inSeries(List.of("series-1")).build(),
+                "en"
+        );
+
+        assertThat(dataset.getHelpText())
+                .containsEntry("title", "A descriptive title.")
+                .doesNotContainKey("inSeries.title");
     }
 
     @Test

--- a/src/test/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/CkanDatasetHelpTextServiceTest.java
+++ b/src/test/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/CkanDatasetHelpTextServiceTest.java
@@ -48,6 +48,35 @@ class CkanDatasetHelpTextServiceTest {
     }
 
     @Test
+    void enrichNormalizesMultilineHelpTextValues() {
+        var ckanQueryApi = mock(CkanQueryApi.class);
+        var service = new CkanDatasetHelpTextService(ckanQueryApi, new ObjectMapper());
+        var dataset = RetrievedDataset.builder().id("dataset-1").build();
+
+        when(ckanQueryApi.gdiDatasetHelpTextsShow(anyString(), anyString(), anyString()))
+                .thenReturn(CkanFilterHelpTextsResponse.builder()
+                        .result(Map.of(
+                                "health_theme",
+                                "A category of the Dataset or tag describing the Dataset.\n",
+                                "access_rights",
+                                "Information that indicates whether\nthis dataset is open or restricted."
+                        ))
+                        .build());
+
+        service.enrich(dataset, CkanPackage.builder().build(), "en");
+
+        assertThat(dataset.getHelpText())
+                .containsEntry(
+                        "healthTheme",
+                        "A category of the Dataset or tag describing the Dataset."
+                )
+                .containsEntry(
+                        "accessRights",
+                        "Information that indicates whether this dataset is open or restricted."
+                );
+    }
+
+    @Test
     void enrichForwardsPreferredLanguageDatasetTypeAndRequestedKeys() {
         var ckanQueryApi = mock(CkanQueryApi.class);
         var service = new CkanDatasetHelpTextService(ckanQueryApi, new ObjectMapper());

--- a/src/test/java/io/github/genomicdatainfrastructure/discovery/filters/infrastructure/ckan/CkanFilterBuilderTest.java
+++ b/src/test/java/io/github/genomicdatainfrastructure/discovery/filters/infrastructure/ckan/CkanFilterBuilderTest.java
@@ -328,6 +328,12 @@ class CkanFilterBuilderTest {
         }
 
         @Override
+        public CkanFilterHelpTextsResponse gdiDatasetHelpTextsShow(String acceptLanguage,
+                String type, String keys) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
         public String retrieveDatasetInFormat(String id, String format, String authorization) {
             throw new UnsupportedOperationException();
         }

--- a/src/test/java/io/github/genomicdatainfrastructure/discovery/filters/infrastructure/ckan/CkanFilterHelpTextServiceTest.java
+++ b/src/test/java/io/github/genomicdatainfrastructure/discovery/filters/infrastructure/ckan/CkanFilterHelpTextServiceTest.java
@@ -44,4 +44,33 @@ class CkanFilterHelpTextServiceTest {
         assertThat(capturedKeys[0])
                 .isEqualTo("[\"title\",\"theme\"]");
     }
+
+    @Test
+    void enrichNormalizesMultilineHelpTextValues() {
+        var ckanQueryApi = mock(CkanQueryApi.class);
+        var service = new CkanFilterHelpTextService(ckanQueryApi, new ObjectMapper());
+
+        when(ckanQueryApi.gdiFilterHelpTextsShow(anyString(), anyString())).thenReturn(
+                CkanFilterHelpTextsResponse.builder()
+                        .result(Map.of(
+                                "health_theme",
+                                "A category of the Dataset or tag describing the Dataset.\n",
+                                "access_rights",
+                                "Information that indicates whether\nthis dataset is open or restricted."
+                        ))
+                        .build());
+
+        var filters = List.of(
+                Filter.builder().key("health_theme").build(),
+                Filter.builder().key("access_rights").build()
+        );
+
+        service.enrich(filters, "en");
+
+        assertThat(filters.get(0).getHelpText())
+                .isEqualTo("A category of the Dataset or tag describing the Dataset.");
+        assertThat(filters.get(1).getHelpText())
+                .isEqualTo(
+                        "Information that indicates whether this dataset is open or restricted.");
+    }
 }

--- a/src/test/java/io/github/genomicdatainfrastructure/discovery/filters/infrastructure/quarkus/RetrieveFiltersTest.java
+++ b/src/test/java/io/github/genomicdatainfrastructure/discovery/filters/infrastructure/quarkus/RetrieveFiltersTest.java
@@ -27,7 +27,7 @@ public class RetrieveFiltersTest extends BaseTest {
                 .get("/api/v1/filters")
                 .then()
                 .statusCode(200)
-                .body("", hasSize(10))
+                .body("", hasSize(9))
                 .body("[0].source", Matchers.equalTo("ckan"))
                 .body("[0].key", Matchers.equalTo("tags"))
                 .body("[0].label", Matchers.equalTo("Keywords"))
@@ -56,12 +56,7 @@ public class RetrieveFiltersTest extends BaseTest {
                 .body("find { it.key == 'vocab_in_series_title' }.type", equalTo("DROPDOWN"))
                 .body("find { it.key == 'vocab_in_series_title' }.label", equalTo("Dataset series"))
                 .body("find { it.key == 'vocab_in_series_title' }.group", equalTo("DEFAULT"))
-                .body("find { it.key == 'vocab_in_series_title' }.values.size()", equalTo(2))
-                .body("find { it.key == 'title' }.source", equalTo("ckan"))
-                .body("find { it.key == 'title' }.type", equalTo("FREE_TEXT"))
-                .body("find { it.key == 'title' }.label", equalTo("Title"))
-                .body("find { it.key == 'title' }.helpText",
-                        equalTo("Use this filter to search datasets by title."));
+                .body("find { it.key == 'vocab_in_series_title' }.values.size()", equalTo(2));
     }
 
     @Test

--- a/src/test/resources/mappings/gdi_dataset_help_texts_show.json
+++ b/src/test/resources/mappings/gdi_dataset_help_texts_show.json
@@ -15,6 +15,10 @@
       "result": {
         "title_translated": "A descriptive title for the dataset.",
         "access_rights": "Information that indicates whether the dataset is open or restricted.",
+        "in_series": "Dataset series this dataset belongs to.",
+        "resource_fields.name_translated": "A descriptive title for the resource.",
+        "resource_fields.format": "File format. If not provided it will be guessed.",
+        "resource_fields.access_services.title": "A title for the data service.",
         "unknown_field": "This should not be exposed."
       }
     }

--- a/src/test/resources/mappings/gdi_dataset_help_texts_show.json
+++ b/src/test/resources/mappings/gdi_dataset_help_texts_show.json
@@ -1,0 +1,22 @@
+{
+  "priority": 1,
+  "request": {
+    "method": "GET",
+    "urlPath": "/api/3/action/gdi_dataset_help_texts_show"
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "jsonBody": {
+      "help": "https://catalogue.portal.dev.gdi.lu/api/3/action/help_show?name=gdi_dataset_help_texts_show",
+      "success": true,
+      "result": {
+        "title_translated": "A descriptive title for the dataset.",
+        "access_rights": "Information that indicates whether the dataset is open or restricted.",
+        "unknown_field": "This should not be exposed."
+      }
+    }
+  }
+}

--- a/src/test/resources/mappings/gdi_dataset_help_texts_show.json.license
+++ b/src/test/resources/mappings/gdi_dataset_help_texts_show.json.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2026 Health-RI
+
+SPDX-License-Identifier: Apache-2.0

--- a/src/test/resources/mappings/gdi_dataset_series_help_texts_show.json
+++ b/src/test/resources/mappings/gdi_dataset_series_help_texts_show.json
@@ -1,0 +1,28 @@
+{
+  "priority": 0,
+  "request": {
+    "method": "GET",
+    "urlPath": "/api/3/action/gdi_dataset_help_texts_show",
+    "queryParameters": {
+      "type": {
+        "equalTo": "dataset_series"
+      }
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "jsonBody": {
+      "help": "https://catalogue.portal.dev.gdi.lu/api/3/action/help_show?name=gdi_dataset_help_texts_show",
+      "success": true,
+      "result": {
+        "title_translated": "A descriptive title for the dataset series.",
+        "notes_translated": "A free-text account of the dataset series.",
+        "frequency": "The frequency with which items are added to the dataset series collection.",
+        "temporal_coverage": "The temporal period or periods the dataset series covers."
+      }
+    }
+  }
+}

--- a/src/test/resources/mappings/package_search_filters.json
+++ b/src/test/resources/mappings/package_search_filters.json
@@ -5,7 +5,7 @@
     "urlPattern": "/api/3/action/enhanced_package_search",
     "bodyPatterns": [
       {
-        "equalToJson": "{\"rows\":0,\"start\":0,\"facet.field\":\"[\\\"title\\\",\\\"access_rights\\\",\\\"theme\\\",\\\"tags\\\",\\\"publisher_name\\\",\\\"res_format\\\",\\\"modified\\\",\\\"number_of_records\\\",\\\"vocab_in_series_title\\\"]\",\"facet.limit\":-1}",
+        "equalToJson": "{\"rows\":0,\"start\":0,\"facet.field\":\"[\\\"access_rights\\\",\\\"theme\\\",\\\"tags\\\",\\\"publisher_name\\\",\\\"res_format\\\",\\\"modified\\\",\\\"number_of_records\\\",\\\"vocab_in_series_title\\\"]\",\"facet.limit\":-1}",
         "ignoreExtraElements": true
       }
     ]
@@ -510,10 +510,6 @@
                 "count": 1
               }
             ]
-          },
-          "title": {
-            "title": "Title",
-            "items": []
           },
           "empty_range_filter": {
             "title": "Empty Range Filter",


### PR DESCRIPTION
## Summary
- Map nested CKAN resource help-text keys to Discovery dot-path keys such as distributions.title, samples.title, analytics.title, and distributions.accessService.title.
- Add inSeries section help text and prefixed joined dataset-series keys such as inSeries.title and inSeries.frequency.
- Keep helpText as a flat string map and preserve existing top-level keys.

## Validation
- mvn -q test -Dtest=CkanDatasetHelpTextServiceTest,RetrieveDatasetTest#can_anonymously_retrieve_dataset
- Full RetrieveDatasetTest class is blocked locally by the known auth-token/dev-services response issue on authenticated tests.

## Summary by Sourcery

Add support for retrieving and exposing normalized CKAN dataset help texts, including nested resource and dataset series fields, while updating dependencies and CI configuration.

New Features:
- Expose a new CKAN API endpoint and service for fetching localized dataset help texts, mapping scheming field names to dataset help-text properties including nested distribution, sample, analytics, and in-series fields.
- Return dataset help text as a flat, string-valued map on the RetrievedDataset model, including dot-path keys for nested structures.

Bug Fixes:
- Normalize multiline CKAN help-text values to single-space-separated strings and drop blank values for both filter and dataset help texts.

Enhancements:
- Wire the new dataset help-text enrichment into dataset retrieval so responses include mapped help-text entries based on CKAN scheming configuration.
- Adjust default dataset filters configuration and expectations to remove the title free-text filter from the filter list.

Build:
- Bump the Quarkus platform BOM version to 3.36.2 in the Maven build.

CI:
- Update GitHub Actions workflows to use a newer graalvm/setup-graalvm action version.

Deployment:
- Update the Docker base image tag for the UBI9 minimal runtime container.

Tests:
- Add unit and integration tests covering CKAN dataset help-text mapping, normalization, language/type/key forwarding, and failure handling, and update existing tests to reflect the new help-text behavior and filter set.