### PR TITLE
Add nested dataset detail help text

### DIFF
--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/CkanDatasetHelpTextService.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/CkanDatasetHelpTextService.java
@@ -133,9 +133,7 @@ public class CkanDatasetHelpTextService {
 
     private String keysAsJson() {
         try {
-            return objectMapper.writeValueAsString(List.copyOf(
-                    SCHEMING_FIELD_TO_DATASET_PROPERTY.keySet()
-            ));
+            return objectMapper.writeValueAsString(SCHEMING_FIELD_TO_DATASET_PROPERTY.keySet());
         } catch (JsonProcessingException exception) {
             throw new IllegalStateException("Could not serialize dataset help-text keys for CKAN",
                     exception);

--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/CkanDatasetHelpTextService.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/CkanDatasetHelpTextService.java
@@ -124,8 +124,9 @@ public class CkanDatasetHelpTextService {
         var mappedHelpTexts = new LinkedHashMap<String, String>();
         helpTexts.forEach((fieldName, helpText) -> {
             var datasetProperty = SCHEMING_FIELD_TO_DATASET_PROPERTY.get(fieldName);
-            if (datasetProperty != null && StringUtils.isNotBlank(helpText)) {
-                mappedHelpTexts.put(datasetProperty, helpText);
+            var normalizedHelpText = StringUtils.normalizeSpace(helpText);
+            if (datasetProperty != null && StringUtils.isNotBlank(normalizedHelpText)) {
+                mappedHelpTexts.put(datasetProperty, normalizedHelpText);
             }
         });
         return mappedHelpTexts;

--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/CkanDatasetHelpTextService.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/CkanDatasetHelpTextService.java
@@ -133,7 +133,9 @@ public class CkanDatasetHelpTextService {
 
     private String keysAsJson() {
         try {
-            return objectMapper.writeValueAsString(SCHEMING_FIELD_TO_DATASET_PROPERTY.keySet());
+            return objectMapper.writeValueAsString(List.copyOf(
+                    SCHEMING_FIELD_TO_DATASET_PROPERTY.keySet()
+            ));
         } catch (JsonProcessingException exception) {
             throw new IllegalStateException("Could not serialize dataset help-text keys for CKAN",
                     exception);

--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/CkanDatasetHelpTextService.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/CkanDatasetHelpTextService.java
@@ -27,60 +27,93 @@ import java.util.logging.Level;
 public class CkanDatasetHelpTextService {
 
     private static final String DEFAULT_DATASET_TYPE = "dataset";
+    private static final String DATASET_SERIES_TYPE = "dataset_series";
 
-    private static final Map<String, String> SCHEMING_FIELD_TO_DATASET_PROPERTY = Map.ofEntries(
-            Map.entry("title_translated", "title"),
-            Map.entry("notes_translated", "description"),
-            Map.entry("tags_translated", "keywords"),
-            Map.entry("contact", "contacts"),
-            Map.entry("publisher", "publishers"),
-            Map.entry("owner_org", "ownerOrg"),
-            Map.entry("url", "url"),
-            Map.entry("issued", "createdAt"),
-            Map.entry("modified", "modifiedAt"),
-            Map.entry("version", "version"),
-            Map.entry("version_notes", "versionNotes"),
-            Map.entry("identifier", "identifier"),
-            Map.entry("frequency", "frequency"),
-            Map.entry("provenance", "provenance"),
-            Map.entry("dcat_type", "dcatType"),
-            Map.entry("temporal_coverage", "temporalCoverage"),
-            Map.entry("temporal_resolution", "temporalResolution"),
-            Map.entry("spatial_coverage", "spatialCoverage"),
-            Map.entry("spatial_resolution_in_meters", "spatialResolutionInMeters"),
-            Map.entry("access_rights", "accessRights"),
-            Map.entry("alternate_identifier", "alternateIdentifier"),
-            Map.entry("theme", "themes"),
-            Map.entry("language", "languages"),
-            Map.entry("documentation", "documentation"),
-            Map.entry("conforms_to", "conformsTo"),
-            Map.entry("is_referenced_by", "isReferencedBy"),
-            Map.entry("distribution", "distributions"),
-            Map.entry("sample", "samples"),
-            Map.entry("analytics", "analytics"),
-            Map.entry("applicable_legislation", "applicableLegislation"),
-            Map.entry("has_version", "hasVersions"),
-            Map.entry("code_values", "codeValues"),
-            Map.entry("coding_system", "codingSystem"),
-            Map.entry("purpose", "purpose"),
-            Map.entry("health_category", "healthCategory"),
-            Map.entry("health_theme", "healthTheme"),
-            Map.entry("legal_basis", "legalBasis"),
-            Map.entry("min_typical_age", "minTypicalAge"),
-            Map.entry("max_typical_age", "maxTypicalAge"),
-            Map.entry("number_of_records", "numberOfRecords"),
-            Map.entry("number_of_unique_individuals", "numberOfUniqueIndividuals"),
-            Map.entry("personal_data", "personalData"),
-            Map.entry("trusted_data_holder", "trustedDataHolder"),
-            Map.entry("population_coverage", "populationCoverage"),
-            Map.entry("retention_period", "retentionPeriod"),
-            Map.entry("hdab", "hdab"),
-            Map.entry("qualified_relation", "qualifiedRelation"),
-            Map.entry("provenance_activity", "provenanceActivity"),
-            Map.entry("qualified_attribution", "qualifiedAttribution"),
-            Map.entry("quality_annotation", "qualityAnnotation"),
-            Map.entry("uri", "uri")
-    );
+    private static final Map<String, List<String>> SCHEMING_FIELD_TO_DATASET_PROPERTY = Map
+            .ofEntries(
+                    Map.entry("title_translated", List.of("title")),
+                    Map.entry("notes_translated", List.of("description")),
+                    Map.entry("tags_translated", List.of("keywords")),
+                    Map.entry("contact", List.of("contacts")),
+                    Map.entry("publisher", List.of("publishers")),
+                    Map.entry("owner_org", List.of("ownerOrg")),
+                    Map.entry("url", List.of("url")),
+                    Map.entry("issued", List.of("createdAt")),
+                    Map.entry("modified", List.of("modifiedAt")),
+                    Map.entry("version", List.of("version")),
+                    Map.entry("version_notes", List.of("versionNotes")),
+                    Map.entry("identifier", List.of("identifier")),
+                    Map.entry("frequency", List.of("frequency")),
+                    Map.entry("provenance", List.of("provenance")),
+                    Map.entry("dcat_type", List.of("dcatType")),
+                    Map.entry("temporal_coverage", List.of("temporalCoverage")),
+                    Map.entry("temporal_resolution", List.of("temporalResolution")),
+                    Map.entry("spatial_coverage", List.of("spatialCoverage")),
+                    Map.entry("spatial_resolution_in_meters", List.of("spatialResolutionInMeters")),
+                    Map.entry("access_rights", List.of("accessRights")),
+                    Map.entry("alternate_identifier", List.of("alternateIdentifier")),
+                    Map.entry("theme", List.of("themes")),
+                    Map.entry("language", List.of("languages")),
+                    Map.entry("documentation", List.of("documentation")),
+                    Map.entry("conforms_to", List.of("conformsTo")),
+                    Map.entry("is_referenced_by", List.of("isReferencedBy")),
+                    Map.entry("distribution", List.of("distributions")),
+                    Map.entry("sample", List.of("samples")),
+                    Map.entry("analytics", List.of("analytics")),
+                    Map.entry("applicable_legislation", List.of("applicableLegislation")),
+                    Map.entry("has_version", List.of("hasVersions")),
+                    Map.entry("code_values", List.of("codeValues")),
+                    Map.entry("coding_system", List.of("codingSystem")),
+                    Map.entry("purpose", List.of("purpose")),
+                    Map.entry("health_category", List.of("healthCategory")),
+                    Map.entry("health_theme", List.of("healthTheme")),
+                    Map.entry("legal_basis", List.of("legalBasis")),
+                    Map.entry("min_typical_age", List.of("minTypicalAge")),
+                    Map.entry("max_typical_age", List.of("maxTypicalAge")),
+                    Map.entry("number_of_records", List.of("numberOfRecords")),
+                    Map.entry("number_of_unique_individuals", List.of("numberOfUniqueIndividuals")),
+                    Map.entry("personal_data", List.of("personalData")),
+                    Map.entry("trusted_data_holder", List.of("trustedDataHolder")),
+                    Map.entry("population_coverage", List.of("populationCoverage")),
+                    Map.entry("retention_period", List.of("retentionPeriod")),
+                    Map.entry("hdab", List.of("hdab")),
+                    Map.entry("qualified_relation", List.of("qualifiedRelation")),
+                    Map.entry("provenance_activity", List.of("provenanceActivity")),
+                    Map.entry("qualified_attribution", List.of("qualifiedAttribution")),
+                    Map.entry("quality_annotation", List.of("qualityAnnotation")),
+                    Map.entry("uri", List.of("uri")),
+                    Map.entry("in_series", List.of("inSeries")),
+                    Map.entry("resource_fields.name_translated",
+                            List.of("distributions.title", "samples.title", "analytics.title")),
+                    Map.entry("resource_fields.description_translated",
+                            List.of("distributions.description", "samples.description",
+                                    "analytics.description")),
+                    Map.entry("resource_fields.format",
+                            List.of("distributions.format", "samples.format", "analytics.format")),
+                    Map.entry("resource_fields.download_url",
+                            List.of("distributions.downloadUrl", "samples.downloadUrl",
+                                    "analytics.downloadUrl")),
+                    Map.entry("resource_fields.access_services", List.of(
+                            "distributions.accessService")),
+                    Map.entry("resource_fields.access_services.title",
+                            List.of("distributions.accessService.title")),
+                    Map.entry("resource_fields.access_services.description",
+                            List.of("distributions.accessService.description"))
+            );
+
+    private static final Map<String, List<String>> SERIES_FIELD_TO_IN_SERIES_PROPERTY = Map
+            .ofEntries(
+                    Map.entry("title_translated", List.of("inSeries.title")),
+                    Map.entry("notes_translated", List.of("inSeries.description")),
+                    Map.entry("frequency", List.of("inSeries.frequency")),
+                    Map.entry("temporal_coverage", List.of("inSeries.temporalCoverage")),
+                    Map.entry("applicable_legislation", List.of("inSeries.applicableLegislation")),
+                    Map.entry("contact", List.of("inSeries.contacts")),
+                    Map.entry("publisher", List.of("inSeries.publishers")),
+                    Map.entry("issued", List.of("inSeries.issued")),
+                    Map.entry("modified", List.of("inSeries.modified")),
+                    Map.entry("spatial_coverage", List.of("inSeries.spatial"))
+            );
 
     private final CkanQueryApi ckanQueryApi;
     private final ObjectMapper objectMapper;
@@ -106,35 +139,71 @@ public class CkanDatasetHelpTextService {
 
     private Map<String, String> retrieveHelpTexts(CkanPackage ckanPackage,
             String preferredLanguage) {
+        var helpTexts = new LinkedHashMap<String, String>();
+        helpTexts.putAll(retrievePackageHelpTexts(ckanPackage, preferredLanguage));
+        helpTexts.putAll(retrieveJoinedSeriesHelpTexts(ckanPackage, preferredLanguage));
+        return helpTexts;
+    }
+
+    private Map<String, String> retrievePackageHelpTexts(CkanPackage ckanPackage,
+            String preferredLanguage) {
         try {
-            return mapToDatasetProperties(Optional.ofNullable(ckanQueryApi.gdiDatasetHelpTextsShow(
-                    preferredLanguage,
-                    schemingType(ckanPackage),
-                    keysAsJson()
-            ))
-                    .map(CkanFilterHelpTextsResponse::getResult)
-                    .orElseGet(Map::of));
+            return mapToDatasetProperties(
+                    Optional.ofNullable(ckanQueryApi.gdiDatasetHelpTextsShow(
+                            preferredLanguage,
+                            schemingType(ckanPackage),
+                            keysAsJson(SCHEMING_FIELD_TO_DATASET_PROPERTY)
+                    ))
+                            .map(CkanFilterHelpTextsResponse::getResult)
+                            .orElseGet(Map::of),
+                    SCHEMING_FIELD_TO_DATASET_PROPERTY
+            );
         } catch (RuntimeException exception) {
             log.log(Level.WARNING, "Could not retrieve CKAN dataset help texts", exception);
             return Map.of();
         }
     }
 
-    private Map<String, String> mapToDatasetProperties(Map<String, String> helpTexts) {
+    private Map<String, String> retrieveJoinedSeriesHelpTexts(CkanPackage ckanPackage,
+            String preferredLanguage) {
+        if (ckanPackage.getInSeries() == null || ckanPackage.getInSeries().isEmpty()) {
+            return Map.of();
+        }
+
+        try {
+            return mapToDatasetProperties(
+                    Optional.ofNullable(ckanQueryApi.gdiDatasetHelpTextsShow(
+                            preferredLanguage,
+                            DATASET_SERIES_TYPE,
+                            keysAsJson(SERIES_FIELD_TO_IN_SERIES_PROPERTY)
+                    ))
+                            .map(CkanFilterHelpTextsResponse::getResult)
+                            .orElseGet(Map::of),
+                    SERIES_FIELD_TO_IN_SERIES_PROPERTY
+            );
+        } catch (RuntimeException exception) {
+            log.log(Level.WARNING, "Could not retrieve CKAN dataset series help texts", exception);
+            return Map.of();
+        }
+    }
+
+    private Map<String, String> mapToDatasetProperties(Map<String, String> helpTexts,
+            Map<String, List<String>> fieldMappings) {
         var mappedHelpTexts = new LinkedHashMap<String, String>();
         helpTexts.forEach((fieldName, helpText) -> {
-            var datasetProperty = SCHEMING_FIELD_TO_DATASET_PROPERTY.get(fieldName);
+            var datasetProperties = fieldMappings.get(fieldName);
             var normalizedHelpText = StringUtils.normalizeSpace(helpText);
-            if (datasetProperty != null && StringUtils.isNotBlank(normalizedHelpText)) {
-                mappedHelpTexts.put(datasetProperty, normalizedHelpText);
+            if (datasetProperties != null && StringUtils.isNotBlank(normalizedHelpText)) {
+                datasetProperties.forEach(datasetProperty -> mappedHelpTexts.put(datasetProperty,
+                        normalizedHelpText));
             }
         });
         return mappedHelpTexts;
     }
 
-    private String keysAsJson() {
+    private String keysAsJson(Map<String, List<String>> fieldMappings) {
         try {
-            return objectMapper.writeValueAsString(SCHEMING_FIELD_TO_DATASET_PROPERTY.keySet());
+            return objectMapper.writeValueAsString(fieldMappings.keySet());
         } catch (JsonProcessingException exception) {
             throw new IllegalStateException("Could not serialize dataset help-text keys for CKAN",
                     exception);

--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/CkanDatasetHelpTextService.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/CkanDatasetHelpTextService.java
@@ -28,6 +28,11 @@ public class CkanDatasetHelpTextService {
 
     private static final String DEFAULT_DATASET_TYPE = "dataset";
     private static final String DATASET_SERIES_TYPE = "dataset_series";
+    private static final List<String> RESOURCE_SECTION_PROPERTIES = List.of(
+            "distributions",
+            "samples",
+            "analytics"
+    );
 
     private static final Map<String, List<String>> SCHEMING_FIELD_TO_DATASET_PROPERTY = Map
             .ofEntries(
@@ -84,21 +89,20 @@ public class CkanDatasetHelpTextService {
                     Map.entry("uri", List.of("uri")),
                     Map.entry("in_series", List.of("inSeries")),
                     Map.entry("resource_fields.name_translated",
-                            List.of("distributions.title", "samples.title", "analytics.title")),
+                            resourceSectionProperties("title")),
                     Map.entry("resource_fields.description_translated",
-                            List.of("distributions.description", "samples.description",
-                                    "analytics.description")),
+                            resourceSectionProperties("description")),
                     Map.entry("resource_fields.format",
-                            List.of("distributions.format", "samples.format", "analytics.format")),
+                            resourceSectionProperties("format")),
                     Map.entry("resource_fields.download_url",
-                            List.of("distributions.downloadUrl", "samples.downloadUrl",
-                                    "analytics.downloadUrl")),
+                            resourceSectionProperties("downloadUrl")),
+                    // Access services are only exposed for distributions in the Discovery API.
                     Map.entry("resource_fields.access_services", List.of(
                             "distributions.accessService")),
                     Map.entry("resource_fields.access_services.title",
-                            List.of("distributions.accessService.title")),
+                            resourceAccessServiceProperties("title")),
                     Map.entry("resource_fields.access_services.description",
-                            List.of("distributions.accessService.description"))
+                            resourceAccessServiceProperties("description"))
             );
 
     private static final Map<String, List<String>> SERIES_FIELD_TO_IN_SERIES_PROPERTY = Map
@@ -192,13 +196,22 @@ public class CkanDatasetHelpTextService {
         var mappedHelpTexts = new LinkedHashMap<String, String>();
         helpTexts.forEach((fieldName, helpText) -> {
             var datasetProperties = fieldMappings.get(fieldName);
-            var normalizedHelpText = StringUtils.normalizeSpace(helpText);
+            var normalizedHelpText = normalizeHelpText(helpText);
             if (datasetProperties != null && StringUtils.isNotBlank(normalizedHelpText)) {
                 datasetProperties.forEach(datasetProperty -> mappedHelpTexts.put(datasetProperty,
                         normalizedHelpText));
             }
         });
         return mappedHelpTexts;
+    }
+
+    private String normalizeHelpText(String helpText) {
+        if (helpText == null) {
+            return null;
+        }
+
+        var normalizedHelpText = StringUtils.normalizeSpace(helpText);
+        return StringUtils.isBlank(normalizedHelpText) ? null : normalizedHelpText;
     }
 
     private String keysAsJson(Map<String, List<String>> fieldMappings) {
@@ -229,5 +242,15 @@ public class CkanDatasetHelpTextService {
             }
         }
         return Optional.empty();
+    }
+
+    private static List<String> resourceSectionProperties(String propertyName) {
+        return RESOURCE_SECTION_PROPERTIES.stream()
+                .map(section -> section + "." + propertyName)
+                .toList();
+    }
+
+    private static List<String> resourceAccessServiceProperties(String propertyName) {
+        return List.of("distributions.accessService." + propertyName);
     }
 }

--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/filters/infrastructure/ckan/CkanFilterHelpTextService.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/filters/infrastructure/ckan/CkanFilterHelpTextService.java
@@ -13,6 +13,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.ws.rs.ProcessingException;
 import jakarta.ws.rs.WebApplicationException;
 import lombok.extern.java.Log;
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 
 import java.util.List;
@@ -43,7 +44,8 @@ public class CkanFilterHelpTextService {
             return filters;
         }
 
-        filters.forEach(filter -> filter.setHelpText(helpTexts.get(filter.getKey())));
+        filters.forEach(filter -> filter.setHelpText(normalizeHelpText(helpTexts.get(filter
+                .getKey()))));
         return filters;
     }
 
@@ -76,5 +78,10 @@ public class CkanFilterHelpTextService {
         } catch (JsonProcessingException exception) {
             throw new IllegalStateException("Could not serialize filter keys for CKAN", exception);
         }
+    }
+
+    private String normalizeHelpText(String helpText) {
+        var normalizedHelpText = StringUtils.normalizeSpace(helpText);
+        return StringUtils.isBlank(normalizedHelpText) ? null : normalizedHelpText;
     }
 }

--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/filters/infrastructure/ckan/CkanFilterHelpTextService.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/filters/infrastructure/ckan/CkanFilterHelpTextService.java
@@ -81,6 +81,10 @@ public class CkanFilterHelpTextService {
     }
 
     private String normalizeHelpText(String helpText) {
+        if (helpText == null) {
+            return null;
+        }
+
         var normalizedHelpText = StringUtils.normalizeSpace(helpText);
         return StringUtils.isBlank(normalizedHelpText) ? null : normalizedHelpText;
     }

--- a/src/test/java/io/github/genomicdatainfrastructure/discovery/api/RetrieveDatasetTest.java
+++ b/src/test/java/io/github/genomicdatainfrastructure/discovery/api/RetrieveDatasetTest.java
@@ -24,7 +24,22 @@ class RetrieveDatasetTest extends BaseTest {
                 .statusCode(200)
                 .body("helpText.title", equalTo("A descriptive title for the dataset."))
                 .body("helpText.accessRights",
-                        equalTo("Information that indicates whether the dataset is open or restricted."));
+                        equalTo("Information that indicates whether the dataset is open or restricted."))
+                .body("helpText.inSeries", equalTo("Dataset series this dataset belongs to."))
+                .body("helpText['distributions.title']",
+                        equalTo("A descriptive title for the resource."))
+                .body("helpText['samples.title']",
+                        equalTo("A descriptive title for the resource."))
+                .body("helpText['analytics.title']",
+                        equalTo("A descriptive title for the resource."))
+                .body("helpText['distributions.format']",
+                        equalTo("File format. If not provided it will be guessed."))
+                .body("helpText['distributions.accessService.title']",
+                        equalTo("A title for the data service."))
+                .body("helpText['inSeries.title']",
+                        equalTo("A descriptive title for the dataset series."))
+                .body("helpText['inSeries.frequency']",
+                        equalTo("The frequency with which items are added to the dataset series collection."));
     }
 
     @Test

--- a/src/test/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/CkanDatasetHelpTextServiceTest.java
+++ b/src/test/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/CkanDatasetHelpTextServiceTest.java
@@ -38,9 +38,13 @@ class CkanDatasetHelpTextServiceTest {
                                 "access_rights", "Access conditions.",
                                 "in_series", "Dataset series this dataset belongs to.",
                                 "resource_fields.name_translated", "A resource title.",
+                                "resource_fields.description_translated", "A resource description.",
                                 "resource_fields.format", "Resource format.",
+                                "resource_fields.download_url", "https://example.org/download.csv",
                                 "resource_fields.access_services.title",
                                 "A data service title.",
+                                "resource_fields.access_services.description",
+                                "A data service description.",
                                 "unknown_field", "Not exposed."
                         ))
                         .build());
@@ -54,10 +58,18 @@ class CkanDatasetHelpTextServiceTest {
                 .containsEntry("distributions.title", "A resource title.")
                 .containsEntry("samples.title", "A resource title.")
                 .containsEntry("analytics.title", "A resource title.")
+                .containsEntry("distributions.description", "A resource description.")
+                .containsEntry("samples.description", "A resource description.")
+                .containsEntry("analytics.description", "A resource description.")
                 .containsEntry("distributions.format", "Resource format.")
                 .containsEntry("samples.format", "Resource format.")
                 .containsEntry("analytics.format", "Resource format.")
+                .containsEntry("distributions.downloadUrl", "https://example.org/download.csv")
+                .containsEntry("samples.downloadUrl", "https://example.org/download.csv")
+                .containsEntry("analytics.downloadUrl", "https://example.org/download.csv")
                 .containsEntry("distributions.accessService.title", "A data service title.")
+                .containsEntry("distributions.accessService.description",
+                        "A data service description.")
                 .doesNotContainKey("unknown_field");
     }
 
@@ -231,6 +243,25 @@ class CkanDatasetHelpTextServiceTest {
         var result = service.enrich(dataset, CkanPackage.builder().build(), "en");
 
         assertThat(result).isSameAs(dataset);
+        assertThat(dataset.getHelpText()).isNull();
+    }
+
+    @Test
+    void enrichSkipsNullHelpTextValues() {
+        var ckanQueryApi = mock(CkanQueryApi.class);
+        var service = new CkanDatasetHelpTextService(ckanQueryApi, new ObjectMapper());
+        var dataset = RetrievedDataset.builder().id("dataset-1").build();
+        var result = new java.util.LinkedHashMap<String, String>();
+        result.put("title_translated", null);
+        result.put("resource_fields.format", null);
+
+        when(ckanQueryApi.gdiDatasetHelpTextsShow(anyString(), anyString(), anyString()))
+                .thenReturn(CkanFilterHelpTextsResponse.builder()
+                        .result(result)
+                        .build());
+
+        service.enrich(dataset, CkanPackage.builder().build(), "en");
+
         assertThat(dataset.getHelpText()).isNull();
     }
 }

--- a/src/test/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/CkanDatasetHelpTextServiceTest.java
+++ b/src/test/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/CkanDatasetHelpTextServiceTest.java
@@ -17,6 +17,7 @@ import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.CkanPacka
 import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.CkanValueLabel;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
 import java.util.Map;
 
 class CkanDatasetHelpTextServiceTest {
@@ -35,6 +36,11 @@ class CkanDatasetHelpTextServiceTest {
                         .result(Map.of(
                                 "title_translated", "A descriptive title.",
                                 "access_rights", "Access conditions.",
+                                "in_series", "Dataset series this dataset belongs to.",
+                                "resource_fields.name_translated", "A resource title.",
+                                "resource_fields.format", "Resource format.",
+                                "resource_fields.access_services.title",
+                                "A data service title.",
                                 "unknown_field", "Not exposed."
                         ))
                         .build());
@@ -44,6 +50,14 @@ class CkanDatasetHelpTextServiceTest {
         assertThat(dataset.getHelpText())
                 .containsEntry("title", "A descriptive title.")
                 .containsEntry("accessRights", "Access conditions.")
+                .containsEntry("inSeries", "Dataset series this dataset belongs to.")
+                .containsEntry("distributions.title", "A resource title.")
+                .containsEntry("samples.title", "A resource title.")
+                .containsEntry("analytics.title", "A resource title.")
+                .containsEntry("distributions.format", "Resource format.")
+                .containsEntry("samples.format", "Resource format.")
+                .containsEntry("analytics.format", "Resource format.")
+                .containsEntry("distributions.accessService.title", "A data service title.")
                 .doesNotContainKey("unknown_field");
     }
 
@@ -106,7 +120,80 @@ class CkanDatasetHelpTextServiceTest {
         assertThat(capturedType[0]).isEqualTo("dataset_series");
         assertThat(capturedKeys[0])
                 .contains("\"title_translated\"")
-                .contains("\"access_rights\"");
+                .contains("\"access_rights\"")
+                .contains("\"resource_fields.name_translated\"")
+                .contains("\"resource_fields.access_services.title\"");
+    }
+
+    @Test
+    void enrichAddsJoinedDatasetSeriesHelpTextWithInSeriesPrefix() {
+        var ckanQueryApi = mock(CkanQueryApi.class);
+        var service = new CkanDatasetHelpTextService(ckanQueryApi, new ObjectMapper());
+        var dataset = RetrievedDataset.builder().id("dataset-1").build();
+
+        when(ckanQueryApi.gdiDatasetHelpTextsShow(anyString(), anyString(), anyString()))
+                .thenAnswer(invocation -> {
+                    var type = invocation.getArgument(1, String.class);
+                    if ("dataset_series".equals(type)) {
+                        return CkanFilterHelpTextsResponse.builder()
+                                .result(Map.of(
+                                        "title_translated",
+                                        "A descriptive title for the dataset series.",
+                                        "notes_translated", "A description of the dataset series.",
+                                        "frequency", "The series publication frequency.",
+                                        "temporal_coverage",
+                                        "The temporal period the series covers."
+                                ))
+                                .build();
+                    }
+
+                    return CkanFilterHelpTextsResponse.builder()
+                            .result(Map.of("title_translated", "A descriptive title."))
+                            .build();
+                });
+
+        service.enrich(
+                dataset,
+                CkanPackage.builder().inSeries(List.of("series-1")).build(),
+                "en"
+        );
+
+        assertThat(dataset.getHelpText())
+                .containsEntry("title", "A descriptive title.")
+                .containsEntry("inSeries.title", "A descriptive title for the dataset series.")
+                .containsEntry("inSeries.description", "A description of the dataset series.")
+                .containsEntry("inSeries.frequency", "The series publication frequency.")
+                .containsEntry("inSeries.temporalCoverage",
+                        "The temporal period the series covers.");
+    }
+
+    @Test
+    void enrichKeepsDatasetHelpTextWhenJoinedSeriesHelpTextRequestFails() {
+        var ckanQueryApi = mock(CkanQueryApi.class);
+        var service = new CkanDatasetHelpTextService(ckanQueryApi, new ObjectMapper());
+        var dataset = RetrievedDataset.builder().id("dataset-1").build();
+
+        when(ckanQueryApi.gdiDatasetHelpTextsShow(anyString(), anyString(), anyString()))
+                .thenAnswer(invocation -> {
+                    var type = invocation.getArgument(1, String.class);
+                    if ("dataset_series".equals(type)) {
+                        throw new RuntimeException("CKAN unavailable");
+                    }
+
+                    return CkanFilterHelpTextsResponse.builder()
+                            .result(Map.of("title_translated", "A descriptive title."))
+                            .build();
+                });
+
+        service.enrich(
+                dataset,
+                CkanPackage.builder().inSeries(List.of("series-1")).build(),
+                "en"
+        );
+
+        assertThat(dataset.getHelpText())
+                .containsEntry("title", "A descriptive title.")
+                .doesNotContainKey("inSeries.title");
     }
 
     @Test

--- a/src/test/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/CkanDatasetHelpTextServiceTest.java
+++ b/src/test/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/CkanDatasetHelpTextServiceTest.java
@@ -48,6 +48,35 @@ class CkanDatasetHelpTextServiceTest {
     }
 
     @Test
+    void enrichNormalizesMultilineHelpTextValues() {
+        var ckanQueryApi = mock(CkanQueryApi.class);
+        var service = new CkanDatasetHelpTextService(ckanQueryApi, new ObjectMapper());
+        var dataset = RetrievedDataset.builder().id("dataset-1").build();
+
+        when(ckanQueryApi.gdiDatasetHelpTextsShow(anyString(), anyString(), anyString()))
+                .thenReturn(CkanFilterHelpTextsResponse.builder()
+                        .result(Map.of(
+                                "health_theme",
+                                "A category of the Dataset or tag describing the Dataset.\n",
+                                "access_rights",
+                                "Information that indicates whether\nthis dataset is open or restricted."
+                        ))
+                        .build());
+
+        service.enrich(dataset, CkanPackage.builder().build(), "en");
+
+        assertThat(dataset.getHelpText())
+                .containsEntry(
+                        "healthTheme",
+                        "A category of the Dataset or tag describing the Dataset."
+                )
+                .containsEntry(
+                        "accessRights",
+                        "Information that indicates whether this dataset is open or restricted."
+                );
+    }
+
+    @Test
     void enrichForwardsPreferredLanguageDatasetTypeAndRequestedKeys() {
         var ckanQueryApi = mock(CkanQueryApi.class);
         var service = new CkanDatasetHelpTextService(ckanQueryApi, new ObjectMapper());

--- a/src/test/java/io/github/genomicdatainfrastructure/discovery/filters/infrastructure/ckan/CkanFilterHelpTextServiceTest.java
+++ b/src/test/java/io/github/genomicdatainfrastructure/discovery/filters/infrastructure/ckan/CkanFilterHelpTextServiceTest.java
@@ -44,4 +44,33 @@ class CkanFilterHelpTextServiceTest {
         assertThat(capturedKeys[0])
                 .isEqualTo("[\"title\",\"theme\"]");
     }
+
+    @Test
+    void enrichNormalizesMultilineHelpTextValues() {
+        var ckanQueryApi = mock(CkanQueryApi.class);
+        var service = new CkanFilterHelpTextService(ckanQueryApi, new ObjectMapper());
+
+        when(ckanQueryApi.gdiFilterHelpTextsShow(anyString(), anyString())).thenReturn(
+                CkanFilterHelpTextsResponse.builder()
+                        .result(Map.of(
+                                "health_theme",
+                                "A category of the Dataset or tag describing the Dataset.\n",
+                                "access_rights",
+                                "Information that indicates whether\nthis dataset is open or restricted."
+                        ))
+                        .build());
+
+        var filters = List.of(
+                Filter.builder().key("health_theme").build(),
+                Filter.builder().key("access_rights").build()
+        );
+
+        service.enrich(filters, "en");
+
+        assertThat(filters.get(0).getHelpText())
+                .isEqualTo("A category of the Dataset or tag describing the Dataset.");
+        assertThat(filters.get(1).getHelpText())
+                .isEqualTo(
+                        "Information that indicates whether this dataset is open or restricted.");
+    }
 }

--- a/src/test/java/io/github/genomicdatainfrastructure/discovery/filters/infrastructure/ckan/CkanFilterHelpTextServiceTest.java
+++ b/src/test/java/io/github/genomicdatainfrastructure/discovery/filters/infrastructure/ckan/CkanFilterHelpTextServiceTest.java
@@ -16,6 +16,7 @@ import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.CkanFilte
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 class CkanFilterHelpTextServiceTest {
@@ -72,5 +73,25 @@ class CkanFilterHelpTextServiceTest {
         assertThat(filters.get(1).getHelpText())
                 .isEqualTo(
                         "Information that indicates whether this dataset is open or restricted.");
+    }
+
+    @Test
+    void enrichSkipsNullHelpTextValues() {
+        var ckanQueryApi = mock(CkanQueryApi.class);
+        var service = new CkanFilterHelpTextService(ckanQueryApi, new ObjectMapper());
+
+        var result = new LinkedHashMap<String, String>();
+        result.put("title", null);
+
+        when(ckanQueryApi.gdiFilterHelpTextsShow(anyString(), anyString())).thenReturn(
+                CkanFilterHelpTextsResponse.builder()
+                        .result(result)
+                        .build());
+
+        var filters = List.of(Filter.builder().key("title").build());
+
+        service.enrich(filters, "en");
+
+        assertThat(filters.get(0).getHelpText()).isNull();
     }
 }

--- a/src/test/resources/mappings/gdi_dataset_help_texts_show.json
+++ b/src/test/resources/mappings/gdi_dataset_help_texts_show.json
@@ -15,6 +15,10 @@
       "result": {
         "title_translated": "A descriptive title for the dataset.",
         "access_rights": "Information that indicates whether the dataset is open or restricted.",
+        "in_series": "Dataset series this dataset belongs to.",
+        "resource_fields.name_translated": "A descriptive title for the resource.",
+        "resource_fields.format": "File format. If not provided it will be guessed.",
+        "resource_fields.access_services.title": "A title for the data service.",
         "unknown_field": "This should not be exposed."
       }
     }

--- a/src/test/resources/mappings/gdi_dataset_series_help_texts_show.json
+++ b/src/test/resources/mappings/gdi_dataset_series_help_texts_show.json
@@ -1,0 +1,28 @@
+{
+  "priority": 0,
+  "request": {
+    "method": "GET",
+    "urlPath": "/api/3/action/gdi_dataset_help_texts_show",
+    "queryParameters": {
+      "type": {
+        "equalTo": "dataset_series"
+      }
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "jsonBody": {
+      "help": "https://catalogue.portal.dev.gdi.lu/api/3/action/help_show?name=gdi_dataset_help_texts_show",
+      "success": true,
+      "result": {
+        "title_translated": "A descriptive title for the dataset series.",
+        "notes_translated": "A free-text account of the dataset series.",
+        "frequency": "The frequency with which items are added to the dataset series collection.",
+        "temporal_coverage": "The temporal period or periods the dataset series covers."
+      }
+    }
+  }
+}

--- a/src/test/resources/mappings/gdi_dataset_series_help_texts_show.json.license
+++ b/src/test/resources/mappings/gdi_dataset_series_help_texts_show.json.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2026 Health-RI
+
+SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
Rebased onto the latest main branch and republished as a fresh PR.

This adds dataset-detail help text from CKAN scheming, including nested dot-path keys for distributions and joined dataset series, while keeping the API response flat and backend-only.

## Summary by Sourcery

Extend CKAN dataset help text enrichment to support nested resource and series fields while normalizing multiline help text values.

New Features:
- Expose help text for nested resource fields (distributions, samples, analytics) and joined dataset series fields via flat, dot-path keys in dataset responses.

Enhancements:
- Normalize and de-duplicate whitespace in dataset and filter help text values before exposing them.
- Separate retrieval of package and joined series help texts, including resilient handling when the series help text request fails.

Tests:
- Add unit and API tests covering nested resource and in-series help text mapping, normalized multiline help texts, CKAN parameter forwarding, and failure handling for series help text retrieval.