### PR TITLE
refactor(GVariantsRepository): enhance filtering logic for population tags and update tests to reflect changes

### DIFF
--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/beacon/persistence/GVariantsRepository.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/beacon/persistence/GVariantsRepository.java
@@ -87,22 +87,37 @@ public class GVariantsRepository implements GVariantsRepositoryPort {
             return false;
         }
 
+        if (requestedCountry.isAll() && requestedSex.isSpecific()) {
+            return populationTag.sex() == requestedSex.sex()
+                    && (populationTag.isSexOnly() || populationTag.isCountryAndSex());
+        }
+
+        if (requestedCountry.isSpecific() && requestedSex.isAll()) {
+            return requestedCountry.country().equals(populationTag.country())
+                    && (populationTag.isCountryOnly() || populationTag.isCountryAndSex());
+        }
+
         boolean countryMustBePresent = !requestedCountry.isUnset();
         boolean sexMustBePresent = !requestedSex.isUnset();
 
+        return countryMatches(populationTag, requestedCountry, countryMustBePresent)
+                && sexMatches(populationTag, requestedSex, sexMustBePresent);
+    }
+
+    private boolean countryMatches(PopulationTag populationTag, CountryFilter requestedCountry,
+            boolean countryMustBePresent) {
         if (countryMustBePresent != (populationTag.country() != null)) {
             return false;
         }
+        return !requestedCountry.isSpecific() || requestedCountry.country().equals(populationTag
+                .country());
+    }
 
+    private boolean sexMatches(PopulationTag populationTag, SexFilter requestedSex,
+            boolean sexMustBePresent) {
         if (sexMustBePresent != (populationTag.sex() != null)) {
             return false;
         }
-
-        if (requestedCountry.isSpecific() && !requestedCountry.country()
-                .equals(populationTag.country())) {
-            return false;
-        }
-
         return !requestedSex.isSpecific() || requestedSex.sex() == populationTag.sex();
     }
 

--- a/src/test/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/beacon/persistence/GVariantsRepositoryTest.java
+++ b/src/test/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/beacon/persistence/GVariantsRepositoryTest.java
@@ -117,7 +117,7 @@ class GVariantsRepositoryTest {
 
         var result = gVariantsRepository.search(query);
 
-        assertEquals(Set.of("FR_Male", "ES_M"), populationsOf(result));
+        assertEquals(Set.of("FR_Male", "ES_M", "Male"), populationsOf(result));
     }
 
     @Test
@@ -128,7 +128,7 @@ class GVariantsRepositoryTest {
 
         var result = gVariantsRepository.search(query);
 
-        assertEquals(Set.of("FR_Male", "FR_Female"), populationsOf(result));
+        assertEquals(Set.of("FR_Male", "FR_Female", "FR"), populationsOf(result));
     }
 
     @Test


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: 2024 PNED G.I.E. -->

<!-- SPDX-License-Identifier: Apache-2.0 -->

## 🚀 Pull Request Checklist

- **Title:**

  - `[ ]` A brief, descriptive title for the changes.

- **Description:**

  - `[ ]` Provide a clear and concise description of your pull request, including the purpose of the changes and the approach you've taken.

- **Context:**

  - `[ ]` Why are these changes necessary? What problem do they solve? Link any related issues.

- **Changes:**

  - `[ ]` List the major changes you've made, ideally organized by commit or feature.

- **Testing:**

  - `[ ]` Describe how the changes have been tested. Include any relevant details about the testing environment and the test cases.

- **Screenshots (if applicable):**

  - `[ ]` If your changes are visual, include screenshots to help explain your changes.

- **Additional Information:**

  - `[ ]` Add any other information that might be useful for reviewers, such as considerations, discussions, or dependencies.

- **Checklist:**
  - `[ ]` I have checked that my code adheres to the project's style guidelines and that my code is well-commented.
  - `[ ]` I have performed self-review of my own code and corrected any misspellings.
  - `[ ]` I have made corresponding changes to the documentation (if applicable).
  - `[ ]` My changes generate no new warnings or errors.
  - `[ ]` I have added tests that prove my fix is effective or that my feature works.
  - `[ ]` New and existing unit tests pass locally with my changes.

## Summary by Sourcery

Refine population tag filtering behavior in GVariantsRepository to better handle combinations of country and sex filters.

Enhancements:
- Adjust population tag matching rules to include sex-only and country-only populations when country or sex is requested as all alongside a specific counterpart.

Tests:
- Update repository search tests to reflect the expanded matching behavior for country-all/sex-specific and country-specific/sex-all queries.