### PR TITLE
Fix/typical age label

### DIFF
--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/filters/infrastructure/ckan/CkanSearchFacetsMapper.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/filters/infrastructure/ckan/CkanSearchFacetsMapper.java
@@ -224,11 +224,20 @@ public class CkanSearchFacetsMapper {
     }
 
     private String resolveLabel(CkanFacet facet, FilterMetadata metadata) {
+        var configuredLabel = metadata != null ? metadata.label : null;
+
+        // For range composites, the facet here is one of the individual components (e.g.
+        // "Minimum Typical Age"), whose title doesn't describe the merged filter as a whole, so
+        // the configured label takes priority over it.
+        if (metadata != null && !metadata.rangeComposite.isEmpty() && configuredLabel != null) {
+            return configuredLabel;
+        }
+
         var facetTitle = facet != null ? facet.getTitle() : null;
         if (facetTitle != null) {
             return facetTitle;
         }
-        return metadata != null ? metadata.label : null;
+        return configuredLabel;
     }
 
     private Optional<FilterRange> resolveStatsRange(FilterMetadata metadata,

--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/filters/infrastructure/ckan/CkanSearchFacetsMapper.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/filters/infrastructure/ckan/CkanSearchFacetsMapper.java
@@ -26,7 +26,6 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -172,9 +171,11 @@ public class CkanSearchFacetsMapper {
     private void mergeRangeComposite(CkanFacet facet, FilterMetadata metadata,
             Map<String, CkanFacet> facets,
             Set<String> skipList) {
-        // Gather individual range components and combine them into the composite facet.
+        // Gather individual range components' items into the composite facet, keeping the
+        // composite facet's own title (e.g. "Age Range"/"Leeftijdsbereik", translated from the
+        // typical_age term) untouched rather than joining the components' titles
+        // (e.g. "Minimum Typical Age - Maximum Typical Age").
         var items = new ArrayList<CkanValueLabel>();
-        var titles = new LinkedHashSet<String>();
 
         for (var component : metadata.rangeComposite) {
             if (!facets.containsKey(component)) {
@@ -182,21 +183,13 @@ public class CkanSearchFacetsMapper {
             }
             var componentFacet = facets.get(component);
             items.addAll(componentFacet.getItems());
-            titles.add(componentFacet.getTitle());
 
             // skip processing the individual components
             skipList.add(component);
         }
 
-        // Replace the items/title with the values collected from the individual component facets, but only
-        // when components were actually found: otherwise keep the composite facet's own title/items as
-        // returned by CKAN untouched (e.g. typical_age is requested and translated as its own facet, with no
-        // separate min_typical_age/max_typical_age facets to join).
         if (!items.isEmpty()) {
             facet.items(items);
-        }
-        if (!titles.isEmpty()) {
-            facet.setTitle(String.join(" - ", titles));
         }
     }
 

--- a/src/test/java/io/github/genomicdatainfrastructure/discovery/filters/infrastructure/ckan/CkanFilterBuilderTest.java
+++ b/src/test/java/io/github/genomicdatainfrastructure/discovery/filters/infrastructure/ckan/CkanFilterBuilderTest.java
@@ -171,7 +171,7 @@ class CkanFilterBuilderTest {
         var filters = builder.build(null, "en");
 
         var typicalAge = findFilter(filters, "typical_age");
-        assertThat(typicalAge.getLabel()).isEqualTo("Minimum Typical Age");
+        assertThat(typicalAge.getLabel()).isEqualTo("Age Range");
         assertThat(typicalAge.getType()).isEqualTo(FilterType.NUMBER);
         assertThat(typicalAge.getRange()).isNotNull();
         assertThat(typicalAge.getRange().getMin()).isEqualTo("0");
@@ -368,7 +368,8 @@ class CkanFilterBuilderTest {
                 new TestFilter("number_of_records", FilterType.NUMBER),
                 new TestFilter("tags", FilterType.DROPDOWN),
                 new TestFilter("typical_age", FilterType.NUMBER, Optional.of(List.of(
-                        "min_typical_age", "max_typical_age"))
+                        "min_typical_age", "max_typical_age")),
+                        Optional.of("Age Range")
                 ));
 
         @Override
@@ -447,11 +448,12 @@ class CkanFilterBuilderTest {
     }
 
     @Vetoed
-    private record TestFilter(String key, FilterType type, Optional<List<String>> rangeComposite)
+    private record TestFilter(String key, FilterType type, Optional<List<String>> rangeComposite,
+                              Optional<String> label)
             implements DatasetsConfig.Filter {
 
         TestFilter(String key, FilterType type) {
-            this(key, type, Optional.empty());
+            this(key, type, Optional.empty(), Optional.empty());
         }
 
         @Override
@@ -466,7 +468,7 @@ class CkanFilterBuilderTest {
 
         @Override
         public Optional<String> label() {
-            return Optional.empty();
+            return label;
         }
 
         @Override

--- a/src/test/java/io/github/genomicdatainfrastructure/discovery/filters/infrastructure/ckan/CkanFilterBuilderTest.java
+++ b/src/test/java/io/github/genomicdatainfrastructure/discovery/filters/infrastructure/ckan/CkanFilterBuilderTest.java
@@ -22,6 +22,7 @@ import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.PackagesS
 import jakarta.enterprise.inject.Vetoed;
 import jakarta.ws.rs.ProcessingException;
 
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -124,36 +125,42 @@ class CkanFilterBuilderTest {
 
     @Test
     void buildRangeMetadataForCompositeFacet() {
+        // LinkedHashMap keeps insertion order deterministic, mirroring how CKAN's JSON facet
+        // response is deserialized (order-preserving), so the composite's driving component
+        // (the one whose title/entry is used to build the merged filter) is predictable.
+        var searchFacets = new LinkedHashMap<String, CkanFacet>();
+        searchFacets.put("min_typical_age", CkanFacet.builder()
+                .title("Minimum Typical Age")
+                .items(List.of(
+                        CkanValueLabel.builder()
+                                .name("0")
+                                .displayName("0")
+                                .count(1)
+                                .build(),
+                        CkanValueLabel.builder()
+                                .name("10")
+                                .displayName("10")
+                                .count(2)
+                                .build()))
+                .build());
+        searchFacets.put("max_typical_age", CkanFacet.builder()
+                .title("Maximum Typical Age")
+                .items(List.of(
+                        CkanValueLabel.builder()
+                                .name("100")
+                                .displayName("100")
+                                .count(3)
+                                .build(),
+                        CkanValueLabel.builder()
+                                .name("110")
+                                .displayName("110")
+                                .count(4)
+                                .build()))
+                .build());
+
         var response = PackagesSearchResponse.builder()
                 .result(PackagesSearchResult.builder()
-                        .searchFacets(Map.of(
-                                "min_typical_age", CkanFacet.builder()
-                                        .title("Minimum Typical Age")
-                                        .items(List.of(CkanValueLabel.builder()
-                                                .name("0")
-                                                .displayName("0")
-                                                .count(1)
-                                                .build(),
-                                                CkanValueLabel.builder()
-                                                        .name("10")
-                                                        .displayName("10")
-                                                        .count(2)
-                                                        .build()))
-                                        .build(),
-                                "max_typical_age", CkanFacet.builder()
-                                        .title("Maximum Typical Age")
-                                        .items(List.of(CkanValueLabel.builder()
-                                                .name("100")
-                                                .displayName("100")
-                                                .count(3)
-                                                .build(),
-                                                CkanValueLabel.builder()
-                                                        .name("110")
-                                                        .displayName("110")
-                                                        .count(4)
-                                                        .build()))
-                                        .build()
-                        ))
+                        .searchFacets(searchFacets)
                         .build())
                 .build();
 
@@ -164,11 +171,24 @@ class CkanFilterBuilderTest {
         var filters = builder.build(null, "en");
 
         var typicalAge = findFilter(filters, "typical_age");
-        assertThat(typicalAge.getLabel()).isEqualTo("Minimum Typical Age - Maximum Typical Age");
+        assertThat(typicalAge.getLabel()).isEqualTo("Minimum Typical Age");
         assertThat(typicalAge.getType()).isEqualTo(FilterType.NUMBER);
         assertThat(typicalAge.getRange()).isNotNull();
         assertThat(typicalAge.getRange().getMin()).isEqualTo("0");
         assertThat(typicalAge.getRange().getMax()).isEqualTo("110");
+        assertThat(typicalAge.getOperators())
+                .containsExactly(
+                        Operator.EQUAL_SYMBOL,
+                        Operator.GREATER_THAN_SYMBOL,
+                        Operator.LESS_THAN_SYMBOL,
+                        Operator.GREATER_THAN_OR_EQUAL_TO_SYMBOL,
+                        Operator.LESS_THAN_OR_EQUAL_TO_SYMBOL
+                );
+
+        assertThat(filters)
+                .extracting(Filter::getKey)
+                .contains("typical_age")
+                .doesNotContain("min_typical_age", "max_typical_age");
     }
 
     @Test


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: 2024 PNED G.I.E. -->

<!-- SPDX-License-Identifier: Apache-2.0 -->

## 🚀 Pull Request Checklist

- **Title:**

  - `[ ]` A brief, descriptive title for the changes.

- **Description:**

  - `[ ]` Provide a clear and concise description of your pull request, including the purpose of the changes and the approach you've taken.

- **Context:**

  - `[ ]` Why are these changes necessary? What problem do they solve? Link any related issues.

- **Changes:**

  - `[ ]` List the major changes you've made, ideally organized by commit or feature.

- **Testing:**

  - `[ ]` Describe how the changes have been tested. Include any relevant details about the testing environment and the test cases.

- **Screenshots (if applicable):**

  - `[ ]` If your changes are visual, include screenshots to help explain your changes.

- **Additional Information:**

  - `[ ]` Add any other information that might be useful for reviewers, such as considerations, discussions, or dependencies.

- **Checklist:**
  - `[ ]` I have checked that my code adheres to the project's style guidelines and that my code is well-commented.
  - `[ ]` I have performed self-review of my own code and corrected any misspellings.
  - `[ ]` I have made corresponding changes to the documentation (if applicable).
  - `[ ]` My changes generate no new warnings or errors.
  - `[ ]` I have added tests that prove my fix is effective or that my feature works.
  - `[ ]` New and existing unit tests pass locally with my changes.

## Summary by Sourcery

Adjust composite typical age facet handling to preserve the composite title and expose only the merged range filter.

Bug Fixes:
- Ensure the typical_age composite facet keeps its own title instead of concatenating component titles.
- Hide min_typical_age and max_typical_age component facets from the resulting filters while preserving their merged range values.

Tests:
- Update CkanFilterBuilderTest to rely on deterministic facet order, validate the corrected typical_age label and its supported numeric operators, and assert the absence of component age facets in the output.