### PR TITLE
fix: Invalid Beacon Request When Applying Individual-Level Discovery Filters

### DIFF
--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/config/JacksonConfig.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/config/JacksonConfig.java
@@ -4,11 +4,13 @@
 
 package io.github.genomicdatainfrastructure.discovery.config;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.cfg.CoercionAction;
 import com.fasterxml.jackson.databind.cfg.CoercionInputShape;
 import com.fasterxml.jackson.databind.type.LogicalType;
+import io.github.genomicdatainfrastructure.discovery.remote.beacon.individuals.model.BeaconRequestQueryFilter;
 import io.quarkus.jackson.ObjectMapperCustomizer;
 import jakarta.inject.Singleton;
 
@@ -45,5 +47,10 @@ public class JacksonConfig implements ObjectMapperCustomizer {
         // This handles multilingual fields like name_translated
         objectMapper.coercionConfigFor(LogicalType.Map)
                 .setCoercion(CoercionInputShape.EmptyString, CoercionAction.AsEmpty);
+
+        // Beacon dropdown filters should not serialize optional fields as null.
+        objectMapper.configOverride(BeaconRequestQueryFilter.class).setInclude(
+                JsonInclude.Value.construct(JsonInclude.Include.NON_NULL,
+                        JsonInclude.Include.NON_NULL));
     }
 }

--- a/src/test/java/io/github/genomicdatainfrastructure/discovery/config/JacksonConfigTest.java
+++ b/src/test/java/io/github/genomicdatainfrastructure/discovery/config/JacksonConfigTest.java
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: 2026 PNED G.I.E.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package io.github.genomicdatainfrastructure.discovery.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.genomicdatainfrastructure.discovery.remote.beacon.individuals.model.BeaconRequestQueryFilter;
+import org.junit.jupiter.api.Test;
+
+import static io.github.genomicdatainfrastructure.discovery.remote.beacon.individuals.model.BeaconRequestQueryFilter.OperatorEnum.GREATER_THAN_SYMBOL;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+class JacksonConfigTest {
+
+    private final JacksonConfig jacksonConfig = new JacksonConfig();
+
+    @Test
+    void shouldOmitNullOperatorAndValue_WhenSerializingDropdownBeaconFilter() throws Exception {
+        var mapper = new ObjectMapper();
+        jacksonConfig.customize(mapper);
+
+        var filter = BeaconRequestQueryFilter.builder()
+                .id("NCIT:C16576")
+                .scope("individual")
+                .build();
+
+        var json = mapper.writeValueAsString(filter);
+
+        assertThat(json).contains("\"id\":\"NCIT:C16576\"");
+        assertThat(json).contains("\"scope\":\"individual\"");
+        assertThat(json).doesNotContain("operator");
+        assertThat(json).doesNotContain("value");
+    }
+
+    @Test
+    void shouldKeepOperatorAndValue_WhenSerializingAlphanumericBeaconFilter() throws Exception {
+        var mapper = new ObjectMapper();
+        jacksonConfig.customize(mapper);
+
+        var filter = BeaconRequestQueryFilter.builder()
+                .id("ageOfOnset")
+                .scope("individual")
+                .operator(GREATER_THAN_SYMBOL)
+                .value("20")
+                .build();
+
+        var json = mapper.writeValueAsString(filter);
+
+        assertThat(json).contains("\"operator\":\">\"");
+        assertThat(json).contains("\"value\":\"20\"");
+    }
+}

--- a/src/test/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/quarkus/DatasetSearchTest.java
+++ b/src/test/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/quarkus/DatasetSearchTest.java
@@ -143,6 +143,33 @@ class DatasetSearchTest extends BaseTest {
     }
 
     @Test
+    void shouldOmitNullOperatorAndValue_whenUsingBeaconDropdownFilter() {
+        var query = DatasetSearchQuery.builder()
+                .facets(List.of(
+                        DatasetSearchQueryFacet.builder()
+                                .source("beacon")
+                                .type(FilterType.DROPDOWN)
+                                .key("sex")
+                                .value("NCIT:C16576")
+                                .build()
+                ))
+                .build();
+
+        given()
+                .auth()
+                .oauth2(getAccessToken("alice"))
+                .contentType("application/json")
+                .body(query)
+                .when()
+                .post("/api/v1/datasets/search")
+                .then()
+                .statusCode(200)
+                .body("count", equalTo(1))
+                .body("results[0].identifier", equalTo("27866022694497975"))
+                .body("results[0].recordsCount", equalTo(64));
+    }
+
+    @Test
     void shouldSkipSearchDatasets_whenBeaconReturnsEmptyResultSets() {
         var query = DatasetSearchQuery.builder()
                 .facets(List.of(

--- a/src/test/resources/mappings/individuals_invalid_null_operator_for_dropdown.json
+++ b/src/test/resources/mappings/individuals_invalid_null_operator_for_dropdown.json
@@ -1,0 +1,24 @@
+{
+    "priority": 1,
+    "request": {
+        "method": "POST",
+        "url": "/v2.0.0/individuals",
+        "bodyPatterns": [
+            {
+                "matchesJsonPath": "$.query.filters[?(@.id == 'NCIT:C16576')]"
+            },
+            {
+                "matches": "(?s).*\\\"operator\\\"\\s*:\\s*null.*"
+            }
+        ]
+    },
+    "response": {
+        "status": 422,
+        "headers": {
+            "Content-Type": "application/json"
+        },
+        "jsonBody": {
+            "error": "Invalid request payload: null operator is not allowed for this filter"
+        }
+    }
+}

--- a/src/test/resources/mappings/individuals_invalid_null_operator_for_dropdown.json.license
+++ b/src/test/resources/mappings/individuals_invalid_null_operator_for_dropdown.json.license
@@ -1,0 +1,3 @@
+// SPDX-FileCopyrightText: 2024 PNED G.I.E.
+//
+// SPDX-License-Identifier: Apache-2.0

--- a/src/test/resources/mappings/individuals_invalid_null_value_for_dropdown.json
+++ b/src/test/resources/mappings/individuals_invalid_null_value_for_dropdown.json
@@ -1,0 +1,24 @@
+{
+    "priority": 1,
+    "request": {
+        "method": "POST",
+        "url": "/v2.0.0/individuals",
+        "bodyPatterns": [
+            {
+                "matchesJsonPath": "$.query.filters[?(@.id == 'NCIT:C16576')]"
+            },
+            {
+                "matches": "(?s).*\\\"value\\\"\\s*:\\s*null.*"
+            }
+        ]
+    },
+    "response": {
+        "status": 422,
+        "headers": {
+            "Content-Type": "application/json"
+        },
+        "jsonBody": {
+            "error": "Invalid request payload: null value is not allowed for this filter"
+        }
+    }
+}

--- a/src/test/resources/mappings/individuals_invalid_null_value_for_dropdown.json.license
+++ b/src/test/resources/mappings/individuals_invalid_null_value_for_dropdown.json.license
@@ -1,0 +1,3 @@
+// SPDX-FileCopyrightText: 2024 PNED G.I.E.
+//
+// SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: 2024 PNED G.I.E. -->

<!-- SPDX-License-Identifier: Apache-2.0 -->

## 🚀 Pull Request Checklist

- **Title:**

  - `[ ]` A brief, descriptive title for the changes.

- **Description:**

  - `[ ]` Provide a clear and concise description of your pull request, including the purpose of the changes and the approach you've taken.

- **Context:**

  - `[ ]` Why are these changes necessary? What problem do they solve? Link any related issues.

- **Changes:**

  - `[ ]` List the major changes you've made, ideally organized by commit or feature.

- **Testing:**

  - `[ ]` Describe how the changes have been tested. Include any relevant details about the testing environment and the test cases.

- **Screenshots (if applicable):**

  - `[ ]` If your changes are visual, include screenshots to help explain your changes.

- **Additional Information:**

  - `[ ]` Add any other information that might be useful for reviewers, such as considerations, discussions, or dependencies.

- **Checklist:**
  - `[ ]` I have checked that my code adheres to the project's style guidelines and that my code is well-commented.
  - `[ ]` I have performed self-review of my own code and corrected any misspellings.
  - `[ ]` I have made corresponding changes to the documentation (if applicable).
  - `[ ]` My changes generate no new warnings or errors.
  - `[ ]` I have added tests that prove my fix is effective or that my feature works.
  - `[ ]` New and existing unit tests pass locally with my changes.

## Summary by Sourcery

Adjust Beacon filter serialization to avoid sending null operator and value fields for dropdown-based individual discovery filters.

Bug Fixes:
- Prevent invalid Beacon requests by omitting null operator and value fields from serialized dropdown filters.

Tests:
- Add dataset search test to verify valid results when using Beacon dropdown filters without operator and value.
- Add Jackson configuration tests to ensure BeaconRequestQueryFilter omits null operator and value while preserving them for alphanumeric filters.