### PR TITLE
feat: Enhanced CkanDatasetsMapper to map CkanValueLabel correctly, ensuring null handling for value and label

### DIFF
--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/config/JacksonConfig.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/config/JacksonConfig.java
@@ -10,7 +10,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.cfg.CoercionAction;
 import com.fasterxml.jackson.databind.cfg.CoercionInputShape;
 import com.fasterxml.jackson.databind.type.LogicalType;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import io.github.genomicdatainfrastructure.discovery.datasets.infrastructure.ckan.deserializer.CkanValueLabelDeserializer;
 import io.github.genomicdatainfrastructure.discovery.remote.beacon.individuals.model.BeaconRequestQueryFilter;
+import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.CkanValueLabel;
 import io.quarkus.jackson.ObjectMapperCustomizer;
 import jakarta.inject.Singleton;
 
@@ -29,6 +32,11 @@ public class JacksonConfig implements ObjectMapperCustomizer {
 
     @Override
     public void customize(ObjectMapper objectMapper) {
+        // CKAN may return a value-label either as an object or as a raw string URI.
+        var ckanModule = new SimpleModule();
+        ckanModule.addDeserializer(CkanValueLabel.class, new CkanValueLabelDeserializer());
+        objectMapper.registerModule(ckanModule);
+
         // Accept single values for collection fields when CKAN sends a string instead of an array
         // (e.g. contact.url as "https://..." instead of ["https://..."])
         objectMapper.enable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY);

--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/deserializer/CkanValueLabelDeserializer.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/deserializer/CkanValueLabelDeserializer.java
@@ -1,0 +1,86 @@
+// SPDX-FileCopyrightText: 2026 PNED G.I.E.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package io.github.genomicdatainfrastructure.discovery.datasets.infrastructure.ckan.deserializer;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.CkanValueLabel;
+import org.apache.commons.lang3.StringUtils;
+
+import java.io.IOException;
+
+/**
+ * Handles CKAN value-label fields provided either as objects or plain strings.
+ */
+public class CkanValueLabelDeserializer extends JsonDeserializer<CkanValueLabel> {
+
+    @Override
+    public CkanValueLabel deserialize(JsonParser parser,
+            DeserializationContext context) throws IOException {
+        JsonNode node = parser.getCodec().readTree(parser);
+
+        if (node == null || node.isNull() || node.isMissingNode()) {
+            return null;
+        }
+
+        if (node.isTextual()) {
+            return fromText(node.asText());
+        }
+
+        if (!node.isObject()) {
+            return null;
+        }
+
+        var name = textOrNull(node.get("name"));
+        var displayName = firstNotBlank(
+                textOrNull(node.get("display_name")),
+                textOrNull(node.get("displayName")),
+                name);
+        var count = integerOrNull(node.get("count"));
+
+        return CkanValueLabel.builder()
+                .name(name)
+                .displayName(displayName)
+                .count(count)
+                .build();
+    }
+
+    private static CkanValueLabel fromText(String value) {
+        var normalizedValue = StringUtils.trimToNull(value);
+        if (normalizedValue == null) {
+            return null;
+        }
+
+        return CkanValueLabel.builder()
+                .name(normalizedValue)
+                .displayName(normalizedValue)
+                .build();
+    }
+
+    private static String textOrNull(JsonNode node) {
+        if (node == null || node.isNull()) {
+            return null;
+        }
+        return StringUtils.trimToNull(node.asText());
+    }
+
+    private static Integer integerOrNull(JsonNode node) {
+        if (node == null || node.isNull() || !node.canConvertToInt()) {
+            return null;
+        }
+        return node.asInt();
+    }
+
+    private static String firstNotBlank(String... values) {
+        for (String value : values) {
+            if (StringUtils.isNotBlank(value)) {
+                return value;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/mapper/CkanDatasetsMapper.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/mapper/CkanDatasetsMapper.java
@@ -99,10 +99,32 @@ public interface CkanDatasetsMapper {
     @Mapping(target = "applicableLegislation", source = "applicableLegislation")
     DatasetSeries mapToDatasetSeries(CkanPackage ckanPackage);
 
-    @Mapping(target = "label", source = "displayName")
-    @Mapping(target = "value", source = "name")
-    @Mapping(target = "count", source = "count")
-    ValueLabel map(CkanValueLabel ckanValueLabel);
+    default ValueLabel map(CkanValueLabel ckanValueLabel) {
+        if (ckanValueLabel == null) {
+            return null;
+        }
+
+        var value = StringUtils.trimToNull(ckanValueLabel.getName());
+        var label = StringUtils.trimToNull(ckanValueLabel.getDisplayName());
+
+        if (value == null && label == null) {
+            return null;
+        }
+
+        if (value == null) {
+            value = label;
+        }
+
+        if (label == null) {
+            label = value;
+        }
+
+        return ValueLabel.builder()
+                .value(value)
+                .label(label)
+                .count(ckanValueLabel.getCount())
+                .build();
+    }
 
     @Mapping(target = "accessUrl", source = "accessUrl")
     @Mapping(target = "downloadUrl", source = "downloadUrl")

--- a/src/test/java/io/github/genomicdatainfrastructure/discovery/config/JacksonConfigTest.java
+++ b/src/test/java/io/github/genomicdatainfrastructure/discovery/config/JacksonConfigTest.java
@@ -6,6 +6,7 @@ package io.github.genomicdatainfrastructure.discovery.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.genomicdatainfrastructure.discovery.remote.beacon.individuals.model.BeaconRequestQueryFilter;
+import io.github.genomicdatainfrastructure.discovery.remote.ckan.model.CkanValueLabel;
 import org.junit.jupiter.api.Test;
 
 import static io.github.genomicdatainfrastructure.discovery.remote.beacon.individuals.model.BeaconRequestQueryFilter.OperatorEnum.GREATER_THAN_SYMBOL;
@@ -49,5 +50,54 @@ class JacksonConfigTest {
 
         assertThat(json).contains("\"operator\":\">\"");
         assertThat(json).contains("\"value\":\"20\"");
+    }
+
+    @Test
+    void shouldDeserializeCkanValueLabel_WhenReceivedAsRawString() throws Exception {
+        var mapper = new ObjectMapper();
+        jacksonConfig.customize(mapper);
+
+        var json = """
+                {
+                  "type": "http://example.com/resource/authority/publisher-type/university"
+                }
+                """;
+
+        var result = mapper.readValue(json, CkanTypeHolder.class);
+
+        assertThat(result.type).isNotNull();
+        assertThat(result.type.getName()).isEqualTo(
+                "http://example.com/resource/authority/publisher-type/university");
+        assertThat(result.type.getDisplayName()).isEqualTo(
+                "http://example.com/resource/authority/publisher-type/university");
+    }
+
+    @Test
+    void shouldDeserializeCkanValueLabel_WhenReceivedAsObject() throws Exception {
+        var mapper = new ObjectMapper();
+        jacksonConfig.customize(mapper);
+
+        var json = """
+                {
+                  "type": {
+                    "name": "http://example.com/resource/authority/publisher-type/university",
+                    "display_name": "University",
+                    "count": 4
+                  }
+                }
+                """;
+
+        var result = mapper.readValue(json, CkanTypeHolder.class);
+
+        assertThat(result.type).isNotNull();
+        assertThat(result.type.getName()).isEqualTo(
+                "http://example.com/resource/authority/publisher-type/university");
+        assertThat(result.type.getDisplayName()).isEqualTo("University");
+        assertThat(result.type.getCount()).isEqualTo(4);
+    }
+
+    static class CkanTypeHolder {
+
+        public CkanValueLabel type;
     }
 }

--- a/src/test/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/mapper/CkanDatasetsMapperTest.java
+++ b/src/test/java/io/github/genomicdatainfrastructure/discovery/datasets/infrastructure/ckan/mapper/CkanDatasetsMapperTest.java
@@ -763,6 +763,28 @@ class CkanDatasetsMapperTest {
             assertThat(actual.getDatasetType()).isEqualTo("externally-governed");
         }
 
+        @Test
+        void given_publisher_type_without_value_or_label_should_map_type_as_null() {
+            final var ckanPackage = CkanPackage.builder()
+                    .id("dataset-id")
+                    .title("Dataset title")
+                    .notes("Dataset description")
+                    .publisher(List.of(
+                            CkanAgent.builder()
+                                    .name("publisherName")
+                                    .type(CkanValueLabel.builder().name(null).displayName(null)
+                                            .build())
+                                    .build()))
+                    .build();
+
+            final var actual = mapper.mapToSearchedDataset(ckanPackage);
+
+            assertThat(actual.getPublishers())
+                    .singleElement()
+                    .extracting(Agent::getType)
+                    .isNull();
+        }
+
         @NotNull
         private static SearchedDataset buildSearchedDataset() {
             return SearchedDataset.builder()


### PR DESCRIPTION
- Introduced CkanValueLabelDeserializer to handle CKAN value-label fields as either objects or plain strings.
- Updated JacksonConfig to register the new deserializer for CkanValueLabel.
- Enhanced CkanDatasetsMapper to map CkanValueLabel correctly, ensuring null handling for value and label.
- Added unit tests for deserialization of CkanValueLabel in various formats.

<!-- SPDX-FileCopyrightText: 2024 PNED G.I.E. -->

<!-- SPDX-License-Identifier: Apache-2.0 -->

## 🚀 Pull Request Checklist

- **Title:**

  - `[ ]` A brief, descriptive title for the changes.

- **Description:**

  - `[ ]` Provide a clear and concise description of your pull request, including the purpose of the changes and the approach you've taken.

- **Context:**

  - `[ ]` Why are these changes necessary? What problem do they solve? Link any related issues.

- **Changes:**

  - `[ ]` List the major changes you've made, ideally organized by commit or feature.

- **Testing:**

  - `[ ]` Describe how the changes have been tested. Include any relevant details about the testing environment and the test cases.

- **Screenshots (if applicable):**

  - `[ ]` If your changes are visual, include screenshots to help explain your changes.

- **Additional Information:**

  - `[ ]` Add any other information that might be useful for reviewers, such as considerations, discussions, or dependencies.

- **Checklist:**
  - `[ ]` I have checked that my code adheres to the project's style guidelines and that my code is well-commented.
  - `[ ]` I have performed self-review of my own code and corrected any misspellings.
  - `[ ]` I have made corresponding changes to the documentation (if applicable).
  - `[ ]` My changes generate no new warnings or errors.
  - `[ ]` I have added tests that prove my fix is effective or that my feature works.
  - `[ ]` New and existing unit tests pass locally with my changes.

## Summary by Sourcery

Handle CKAN value-label fields consistently across deserialization and dataset mapping, including robust null and string handling.

New Features:
- Support deserialization of CkanValueLabel from either raw string values or object structures via a custom Jackson deserializer.

Enhancements:
- Register a dedicated CKAN module in JacksonConfig to plug in the CkanValueLabel deserializer.
- Update CkanDatasetsMapper to derive ValueLabel safely from CkanValueLabel, normalizing empty or null value/label fields.

Tests:
- Add JacksonConfig tests covering CkanValueLabel deserialization from raw strings and objects.
- Add mapper tests ensuring publisher types with missing value and label are mapped to null.